### PR TITLE
Include more digestible bits for the introduction of the book

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -14,25 +14,29 @@ maintained[Rust Book](https://doc.rust-lang.org/book/).
 To read the book about gdnative (Godot 3 binding), follow [this link](../gdnative-book).
 
 
-## The basics
+## The purpose of godot-rust
 
-A **library** in its most basic form is a **package of functions**. Godot has several of its own built-in libraries, but like most other programs made
-as a creation tool, it also has the capacity to extend its functionality by accessing collections of libraries made outside of Godot. Those are
-called **extensions**, they usually come in separate files -- typically in the form of file extensions such as `.so` if you're on Linux, `.dll` if
-you're on Windows, or `.dylib` on macOS.
+Godot is a batteries-included game engine that fosters a productive and fun gamedev workflow. It ships GDScript as a built-in scripting
+language and also provides official support for C++ and C# bindings. Its GDExtension mechanism allows more languages to be integrated,
+in our case Rust.
 
-You can expose your extension to Godot using a `.gdextension` file, which contains information about the dynamic library file's location and the
-minimum required Godot version.
-
-The job of a language binding is that we go the other way and we instead treat Godot itself like a library, so that we can have most of the
-interactions of the engine happen in our language of choice. In practice, Godot is still the host engine of our game, so we have to expose things back
-to Godot so that it can use and make available in the editor.
+Rust brings a modern, robust and performant experience to game development. If you are interested in scalability, strong type systems or
+just enjoy Rust as a language, you may consider combining it with Godot, to combine the best of both worlds.
 
 
-# About the extension
+## About this project
+
+godot-rust is a [community-developed][github-contributors] open source project. It is maintained independently of Godot itself, but we are in
+close contact with engine developers, to foster a steady exchange of ideas. This has allowed us to address a lot of Rust's needs upstream, but
+also led to improvements of the engine itself in several cases.
 
 
-## Terminology
+### Currently supported features
+
+For an up-to-date overview of implementation status, consult [issue #24][features].
+
+
+### Terminology
 
 To avoid confusion, here is an explanation of names and technologies you may encounter over the course of this book:
 
@@ -45,12 +49,7 @@ To avoid confusion, here is an explanation of names and technologies you may enc
 - **Extension**: An extension is a C library developed using gdext. It can be loaded by Godot 4.
 
 
-## Currently supported features
-
-For an up-to-date overview of implementation status, consult [issue #24][features].
-
-
-## GDExtension API: what's new
+### GDExtension API: what's new
 
 This section briefly mentions the difference between the native interfaces in Godot 3 and 4 from a functional point of view, without going into Rust.
 
@@ -94,3 +93,4 @@ That said, there are some notable differences:
 [ref-godot-rust]: https://godot-rust.github.io/
 [github-gdext]: https://github.com/godot-rust/gdext
 [github-gdnative]: https://github.com/godot-rust/gdnative
+[github-contributors]: https://github.com/godot-rust/gdext/graphs/contributors

--- a/src/index.md
+++ b/src/index.md
@@ -8,21 +8,40 @@
 
 Welcome to the **godot-rust book**! This is a work-in-progress user guide for **gdext**, the Rust binding for Godot 4.
 
-If you're new to Rust, before getting started, it is highly recommended that you familiarize yourself with concepts outlined
-in the officially maintained [Rust Book](https://doc.rust-lang.org/book/).
+If you're new to Rust, before getting started, it is highly recommended that you familiarize yourself with concepts outlined in the officially
+maintained[Rust Book](https://doc.rust-lang.org/book/).
 
 To read the book about gdnative (Godot 3 binding), follow [this link](../gdnative-book).
 
 
+## The basics
+
+A **library** in its most basic form is a **package of functions**. Godot has several of its own built-in libraries, but like most other programs made
+as a creation tool, it also has the capacity to extend its functionality by accessing collections of libraries made outside of Godot. Those are
+called **extensions**, they usually come in separate files -- typically in the form of file extensions such as `.so` if you're on Linux, `.dll` if
+you're on Windows, or `.dylib` on macOS.
+
+You can expose your extension to Godot using a `.gdextension` file, which contains information about the dynamic library file's location and the
+minimum required Godot version.
+
+The job of a language binding is that we go the other way and we instead treat Godot itself like a library, so that we can have most of the
+interactions of the engine happen in our language of choice. In practice, Godot is still the host engine of our game, so we have to expose things back
+to Godot so that it can use and make available in the editor.
+
+
+# About the extension
+
+
 ## Terminology
 
-To avoid confusion, here is an explanation of names and technologies you may encounter over time.
+To avoid confusion, here is an explanation of names and technologies you may encounter over the course of this book:
 
-- **godot-rust**: The entire project, encompassing Rust bindings for Godot 3 and 4, as well as related efforts (book, community, etc.).
-- [**GDExtension**]: C API provided by Godot 4.
-- [**GDNative**]: C API provided by Godot 3.
-- **gdext** (lowercase): the Rust binding for GDExtension (Godot 4) -- what this book focuses on.
-- **gdnative** (lowercase): the Rust binding for GDNative (Godot 3).
+- [**godot-rust**][ref-godot-rust]: The entire project, encompassing Rust bindings for Godot 3 and 4,
+  as well as related efforts (book, community, etc.).
+- [**GDExtension**][ref-godot-gdext]: C API provided by Godot 4.
+- [**GDNative**][ref-godot-gdnative]: C API provided by Godot 3.
+- [**gdext**][github-gdext] (lowercase): the Rust binding for GDExtension (Godot 4) -- what this book focuses on.
+- [**gdnative**][github-gdnative] (lowercase): the Rust binding for GDNative (Godot 3).
 - **Extension**: An extension is a C library developed using gdext. It can be loaded by Godot 4.
 
 
@@ -33,12 +52,10 @@ For an up-to-date overview of implementation status, consult [issue #24][feature
 
 ## GDExtension API: what's new
 
-This section briefly mentions the difference between the native interfaces in Godot 3 and 4 from a functional point of view,
-without going into Rust.
+This section briefly mentions the difference between the native interfaces in Godot 3 and 4 from a functional point of view, without going into Rust.
 
-While the underlying FFI (foreign function interface) layer has been completely rewritten, a lot of concepts remain the same
-from a user point of view. In particular, Godot's approach with a node-based scene graph, composed of classes in an inheritance
-relation, has not changed.
+While the underlying FFI (foreign function interface) layer has been completely rewritten, a lot of concepts remain the same from a user point of
+view. In particular, Godot's approach with a node-based scene graph, composed of classes in an inheritance relation, has not changed.
 
 That said, there are some notable differences:
 
@@ -72,5 +89,8 @@ That said, there are some notable differences:
 [issue #66231]: https://github.com/godotengine/godot/issues/66231
 [extension-library-doc]: https://godot-rust.github.io/docs/gdext/master/godot/init/trait.ExtensionLibrary.html#method.editor_run_behavior
 
-[**GDNative**]: https://docs.godotengine.org/en/3.5/tutorials/scripting/gdnative/what_is_gdnative.html
-[**GDExtension**]: https://docs.godotengine.org/en/stable/tutorials/scripting/gdextension/what_is_gdextension.html
+[ref-godot-gdnative]: https://docs.godotengine.org/en/3.5/tutorials/scripting/gdnative/what_is_gdnative.html
+[ref-godot-gdext]: https://docs.godotengine.org/en/stable/tutorials/scripting/gdextension/what_is_gdextension.html
+[ref-godot-rust]: https://godot-rust.github.io/
+[github-gdext]: https://github.com/godot-rust/gdext
+[github-gdnative]: https://github.com/godot-rust/gdnative

--- a/src/intro/hello-world.md
+++ b/src/intro/hello-world.md
@@ -4,7 +4,6 @@
   ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -->
 
-
 # Hello World
 
 This page shows you how to develop your own small extension library and load it from Godot.
@@ -16,105 +15,117 @@ It is recommended to follow that alongside this tutorial, in case you're interes
 <!-- toc -->
 
 
-## Connecting Godot and Rust
+## Directory setup
 
-First things first.  
-For the following objective, we'll first make
+We assume the following file structure, with separate directories for the Godot and Rust parts:
 
-- A Cargo crate of your own;
-- A Godot project created;
-
-You can very much start from an already existing Godot project. Here we'll start from scratch for the sake of completeness.
-
-
-### Creating the Godot Project
-
-For this example we're going to create each of the items separated into neighboring folders in the same parent folder. You'll be able to choose
-locations of your own as we progress. Let's start by creating a blank Godot project if you haven't already.
-
-Not much to do here yet, we'll come back to it later.
-
-
-### Creating the Rust Cargo crate
-
-To create a Cargo crate, have your terminal open, navigate to your desired folder and then call `cargo` to create it by typing:
-
-```bash
-cargo new "your_crate_name" --lib
+```txt
+project_dir
+│
+├── .git/
+│
+├── godot/
+│   ├── .godot/
+│   ├── HelloWorld.gdextension
+│   └── project.godot
+│
+└── rust/
+    ├── Cargo.toml
+    ├── src/
+    │   └── lib.rs
+    └── target/
+        └── debug/
 ```
 
-The argument `--lib` will tell `cargo` to create the package from a Library template. From there, we're going to configure it in the file which stores
-its metadata, `Cargo.toml`. This file stores the information we know of the library package and what it uses in order to work with it.
 
-Open `Cargo.toml` in your favorite text editor and edit it as the following:
+## Create a Godot project
+
+We assume a Godot version of 4.1 or later. Feel free to download the latest stable one. You can download in-development ones,
+but we [do not provide official support for those][compatibility], so we recommend stable ones.
+
+Open the Godot project manager and create a blank Godot 4 project. Run the default scene to make sure everything is working.
+Save the changes and consider versioning each step of the tutorial in Git.
+
+
+## Create a Rust crate
+
+To make a new crate with cargo, open your terminal, navigate to your desired folder and then type:
+
+```bash
+cargo new "{YourCrate}" --lib
+```
+
+where `{YourCrate}` will be used as a placeholder for a crate name of your choice. To fit with the file structure, we choose `rust` as the
+crate name. `--lib` is used to create a library (not an executable), but there is some extra configuration that the crate requires.
+
+Open `Cargo.toml` and modify it as follows:
 
 ```toml
 [package]
-name = "rust_project" # Will appear in the filename of the dynamic Rust library you compile.
-version = "0.1.0" # version of your library (your criteria)
-edition = "2021" # Rust edition version (remains unchanged)
+name = "rust_project" # Appears in the filename of the compiled dynamic library.
+version = "0.1.0"     # You can leave version and edition as-is for now.
+edition = "2021"
 
 [lib]
-crate-type = ["cdylib"] # defines the kind of library it will become
+crate-type = ["cdylib"]  # Compile this crate to a dynamic C library.
 
-[dependencies] # lists what your own library needs in order to function
+[dependencies]
 godot = { git = "https://github.com/godot-rust/gdext", branch = "master" }
 ```
 
-
-#### Why "`cdylib`"?
-<!-- editors note: sole reason this header's here is because this marks a quick spot to go back to later on,
-specially if a new reader is just scrolling by around the book. -->
-
-The `cdylib` crate type is a bit unusual in Rust. Instead of building a binary (`bin`, application) or a library to be utilized by other Rust code
+The `cdylib` crate type is not very common in Rust. Instead of building an application (`bin`) or a library to be utilized by other Rust code
 (`lib`), we create a _dynamic_ library, exposing an interface in the C programming language. This dynamic library is loaded by Godot at runtime,
 through the GDExtension interface.
 
-```admonish note
-The main crate of gdext is called `godot`. At this point, it is still hosted on GitHub; in the future, it will be published to crates.io. To fetch the
-latest changes, you can regularly run a `cargo update` (possibly breaking). Keep your `Cargo.lock` file under version control, so that it's easy to
-revert updates.
+```admonish note title="Main crate"
+The main crate of gdext is called `godot`. At this point, it is still hosted on GitHub; in the future, it will be published to crates.io.
+To fetch the latest changes, you can regularly run a `cargo update` (possibly breaking). Keep your `Cargo.lock` file under version control, 
+so that it's easy to revert updates.
 ```
 
-To compile each iteration of the extension as you write your code, you can use `cargo` as you normally do with any other Rust project:
+To compile each iteration of the extension as you write code, you can use `cargo` as you normally do with any other Rust project:
 
 ```bash
 cargo build
 ```
 
-This should output to `rust_project/target/debug/` at least one variation of a compiled library depending on your setup. For instance,
-`librust_project.so` is created if you're on Linux:
+This should output to `{YourCrate}/target/debug/` at least one variation of a compiled library depending on your setup.
+As an example, a Rust crate `hello` on Linux would be compiled to `libhello.so`:
 
 ```log
 $ cargo build
-   Compiling godot4-prebuilt v0.0.0 (https://github.com/godot-rust/godot4-prebuilt?branch=4.1.1#fca6897d)
+   Compiling godot4-prebuilt v0.0.0 
+       (https://github.com/godot-rust/godot4-prebuilt?branch=4.1.1#fca6897d)
    Compiling proc-macro2 v1.0.69
    [...]
    Compiling godot v0.1.0 (https://github.com/godot-rust/gdext?branch=master#66df8f47)
-   Compiling rust_project v0.1.0 (/home/wilker/Documentos/Projects/Programming/Godot/Tutorial/rust_project)
+   Compiling hello v0.1.0 (/path/to/hello)
     Finished dev [unoptimized + debuginfo] target(s) in 1m 46s
 
 $ ls -l
-╭───┬─────────────────────────────────┬──────┬─────────┬────────────────╮
-│ # │              name               │ type │  size   │    modified    │
-├───┼─────────────────────────────────┼──────┼─────────┼────────────────┤
-│ 0 │ target/debug/build              │ dir  │   648 B │ 2 minutes ago  │
-│ 1 │ target/debug/deps               │ dir  │  3.8 KB │ now            │
-│ 2 │ target/debug/examples           │ dir  │     0 B │ 2 minutes ago  │
-│ 3 │ target/debug/incremental        │ dir  │    52 B │ 16 seconds ago │
-│ 4 │ target/debug/librust_project.d  │ file │   190 B │ now            │
-│ ⮞ │ target/debug/librust_project.so │ file │ 62.6 MB │ now            │
-╰───┴─────────────────────────────────┴──────┴─────────┴────────────────╯
+╭───┬──────────────────────────┬──────╮
+│ # │           name           │ type │
+├───┼──────────────────────────┼──────┤
+│ 0 │ target/debug/build       │ dir  │
+│ 1 │ target/debug/deps        │ dir  │
+│ 2 │ target/debug/examples    │ dir  │
+│ 3 │ target/debug/incremental │ dir  │
+│ 4 │ target/debug/libhello.d  │ file │
+│ > │ target/debug/libhello.so │ file │
+╰───┴──────────────────────────┴──────╯
 ```
+
+
+## Wire up Godot with Rust
 
 
 ### `.gdextension` file
 
-The job of this file is to provide Godot with pointers to a library that is compiled elsewhere. We're going to use it to connect Godot to your
-compiled library so it can be used within the context of your Godot project.
+This file tells Godot how to load your compiled Rust extension. It contains the path to the dynamic library, as well as the
+entry point (function) to initialize it with.
 
-First, add an empty `.gdextension` file somewhere in your project folder, which is the equivalent of `.gdnlib` for GDNative. In this case we're
-creating `res://HelloWorld.gdextension` in the root folder of the project. Following along,
+First, add an empty `.gdextension` file anywhere in your project folder. In case you're familiar with Godot 3, this is the equivalent of
+`.gdnlib`. In this case, we create `res://HelloWorld.gdextension` in the root folder of the project and fill it as follows:
 
 ```ini
 [configuration]
@@ -122,79 +133,70 @@ entry_symbol = "gdext_rust_init"
 compatibility_minimum = 4.1
 
 [libraries]
-linux.debug.x86_64 = "res://../{myCrate}/target/debug/lib{myCrate}.so"
+linux.debug.x86_64 =     "res://../rust/target/debug/lib{YourCrate}.so"
+linux.release.x86_64 =   "res://../rust/target/release/lib{YourCrate}.so"
+windows.debug.x86_64 =   "res://../rust/target/debug/{YourCrate}.dll"
+windows.release.x86_64 = "res://../rust/target/release/{YourCrate}.dll"
+macos.debug =            "res://../rust/target/debug/lib{YourCrate}.dylib"
+macos.release =          "res://../rust/target/release/lib{YourCrate}.dylib"
+macos.debug.arm64 =      "res://../rust/target/debug/lib{YourCrate}.dylib"
+macos.release.arm64 =    "res://../rust/target/release/lib{YourCrate}.dylib"
 ```
 
-- The `[configuration]` section should be copied as-is.
-  - The name `gdext_rust_init` for the entry point is provided by **godot-rust**
-    and is required for the extension to initialize;
-  - `compatibility_minimum` is the minimum version of **Godot** required by your extension to work.
-    Opening the project with a version of Godot lower than this will prevent your extension from running;
-- The `[libraries]` section should be updated to match the paths of your dynamic Rust libraries.
-  - `linux.debug.x86_64` is the [**target build**](#other-possible-target-paths) of the **Godot** project.
-  - `{myCrate}` should be replaced with the name of your compiled file. For instance,
-    `librust_project.so` from the name of the library we compiled earlier;
+The `[configuration]` section should be copied as-is.
 
-```admonish note
-For exporting your project, you'll need to use paths inside `res://`. This prefix represents the path to your files **relative to the root folder of
-your project**. You can learn more about Godot's resource paths [here][ref-resource-paths].
-```
+- Key `entry_symbol` refers to the entry point function that **gdext** exposes. We choose `"gdext_rust_init"`, which is gdext's default
+  (but can be configured if needed).
+- Key `compatibility_minimum` specifies the minimum version of **Godot** required by your extension to work.
+  Opening the project with a version of Godot lower than this will prevent your extension from running.
+  - If you build a plugin to be used by others, set this as low as possible for maximum ecosystem compatibility. This might however limit
+    the features you can use.
 
+The `[libraries]` section should be updated to match the paths of your dynamic Rust libraries.
 
-#### Other possible target paths
-
-The following is a list of other possible paths depending on the target of your library. You can copy them as-is for this example, replacing
-`{myCrate}` with the name of your actual library:
-
-```ini
-[configuration] # same as before
-entry_symbol = "gdext_rust_init"
-compatibility_minimum = 4.1
-
-[libraries]
-linux.debug.x86_64 =     "res://../{myCrate}/target/debug/lib{myCrate}.so"
-linux.release.x86_64 =   "res://../{myCrate}/target/release/lib{myCrate}.so"
-windows.debug.x86_64 =   "res://../{myCrate}/target/debug/{myCrate}.dll"
-windows.release.x86_64 = "res://../{myCrate}/target/release/{myCrate}.dll"
-macos.debug =            "res://../{myCrate}/target/debug/lib{myCrate}.dylib"
-macos.release =          "res://../{myCrate}/target/release/lib{myCrate}.dylib"
-macos.debug.arm64 =      "res://../{myCrate}/target/debug/lib{myCrate}.dylib"
-macos.release.arm64 =    "res://../{myCrate}/target/release/lib{myCrate}.dylib"
-```
-
-The `..` is a pointer to a parent folder of the end path.
-e.g Godot will look in a path relative to this project directory's parent folder.
-
+- The keys on the left are the build targets of the **Godot** project.
+  - Consult [GDExtension docs][godot-build-targets] for more possible values.
+- The values on the right are the file paths to your dynamic library.
+  - The `res://` prefix represents the path to files **relative to your Godot directory**.
+    You can learn more about Godot's resource paths [here][godot-resource-paths].
+  - If you remember the file structure, the `godot` and `rust` directories are siblings, so we need to go up one level to reach `rust`.
+- You can add configurations for as many platforms as you like, if you plan to export your project to those later.
+  At the very least, you need to have your current OS in `debug` mode.
 
 ```admonish tip
 You can also employ the use of symbolic links and git submodules and then treat those as regular folders and files. Godot reads those just fine too! 
 ```
 
-```admonish note
-If you specify your cargo compilation target via the `--target` flag or a `.cargo/config.toml` file, the rust library will be placed in a 
-path name that includes target architecture, and the `.gdextension` library paths will need to match. For example, for M1 Macs 
-(`macos.debug.arm64` and `macos.release.arm64`), the path would be `"res://../rust/target/aarch64-apple-darwin/debug/lib{myCrate}.dylib"`.
+```admonish note title="Export paths"
+When exporting your project, you need to use paths _inside_ `res://`.  
+Outside paths like `..` are not supported. 
+```
+
+```admonish note title="Custom Rust targets"
+If you specify your cargo compilation target via the `--target` flag or a `.cargo/config.toml` file, the rust library will be placed in a path name
+that includes target architecture, and the `.gdextension` library paths will need to match. For example, for M1 Macs 
+(`macos.debug.arm64` and `macos.release.arm64`), the path would be `"res://../rust/target/aarch64-apple-darwin/debug/lib{YourCrate}.dylib"`.
 ```
 
 
 ### `extension_list.cfg`
 
-A second file `res://.godot/extension_list.cfg` should be generated once you open the Godot editor for the first time.
-If not, you can also manually create it, simply containing the Godot path to your `.gdextension` file:
+A second file `res://.godot/extension_list.cfg` should be generated once you open the Godot editor for the first time. This file lists all
+extension registered within your project. If the file does not exist, you can also manually create it, simply containing the Godot path to
+your `.gdextension` file:
 
 ```text
 res://HelloWorld.gdextension
 ```
-<!-- TODO: explain further the necessity and functionality of the extension_list.cfg -->
 
 
-## Implementing your extension and your first Node
+## Your first Rust extension
 
 
 ### Rust entry point
 
-[Like mentioned earlier](#why-cdylib), our compiled C library needs to expose an _entry point_ to Godot: a C function that can be called through
-the GDExtension. Setting this up requires quite some low-level [FFI][wikipedia-ffi] code, which is why gdext abstracts it for you.
+As mentioned earlier, our compiled C library needs to expose an _entry point_ to Godot: a C function that can be called through
+the GDExtension. Setting this up requires quite some low-level [FFI][wikipedia-ffi] code, which gdext abstracts for you.
 
 In your `lib.rs`, replace the template with the following:
 
@@ -217,61 +219,15 @@ There are multiple things going on here:
 The last point declares the actual GDExtension entry point, and the proc-macro attribute takes care of the low-level details.
 
 
-#### "Does it load though?"
-
-If you want to see Godot loading your extension, you can override `on_level_init(InitLevel)` from the
-[`ExtensionLibrary`][api-extensionlibrary] trait like so:
-
-```rust
-use godot::prelude::*;
-
-struct MyExtension;
-
-#[gdextension]
-unsafe impl ExtensionLibrary for MyExtension {
-    fn on_level_init(level: InitLevel) {
-        godot_print!("Hello Library!");
-
-        godot_print!("Initialization level: {:?}", level);
-    }
-}
-```
-
-After `cargo build`, Godot should display the following messages when running it from the command line:
-
-
-```log
-Godot/Tutorial/GodotProject
-$ godot4 -e
-Initialize GDExtension API for Rust: Godot Engine v4.2.beta1.official
-Hello Library!
-Initialization level: Core
-Godot Engine v4.2.beta1.official.b1371806a - https://godotengine.org
-Hello Library!
-Initialization level: Servers
-Vulkan API 1.3.246 - Forward+ - Using Vulkan Device #0: AMD - AMD Radeon Vega 8 Graphics (RADV RAVEN)
-
-Hello Library!
-Initialization level: Scene
-Hello Library!
-Initialization level: Editor
-```
-
-```admonish note
-These messages will most likely not show up unless you're either launching [Godot editor from your command line][godot-command-line] by using
-`godot -e` like in this example, or making your gdextension file visible for the first time in Godot while opened.
-```
-
-
-### Your first Rust class
+## Creating a Rust class
 
 Now, let's write Rust code to define a _class_ that can be used in Godot.
 
-Every class inherits an existing Godot-provided class (its _base class_ or just _base_). Rust does not natively support inheritance, but the gdext API
-emulates it to a certain extent.
+Every class inherits an existing Godot-provided class (its _base class_ or just _base_).
+Rust does not natively support inheritance, but the gdext API emulates it to a certain extent.
 
 
-#### Class declaration
+### Class declaration
 
 In this example, we declare a class called `Player`, which inherits [`Sprite2D`][api-sprite2d] (a node type):
 
@@ -301,21 +257,20 @@ Let's break this down.
    `#[derive(GodotClass)]` _automatically_ registers the class -- you don't need an explicit 
    `add_class()` registration call, or a `.gdns` file as it was the case with GDNative.
    
-   You will, however, need to restart the Godot editor for it to take effect.
+   Before Godot 4.2, you will need to restart the Godot editor for it to take effect.
    ```
 
-3. We define two fields `speed` and `angular_speed` for the logic. These are regular Rust fields, no magic involved. More about their use later.
-
-4. The optional `#[class]` attribute configures how the class is registered. In this case, we specify that `Player` inherits Godot's
+3. The optional `#[class]` attribute configures how the class is registered. In this case, we specify that `Player` inherits Godot's
    `Sprite2D` class. If you don't specify the `base` key, the base class will implicitly be `RefCounted`, just as if you omitted the
    `extends` keyword in GDScript.
 
+4. We define two fields `speed` and `angular_speed` for the logic. These are regular Rust fields, no magic involved. More about their use later.
 
 5. The `#[base]` attribute declares the `sprite` field, which allows `self` to access the base instance (via composition, as Rust does not have
    native inheritance).
 
    - The field must have type `Base<T>`.
-     - `T` must match the declared base class, e.g. `Sprite2D` for `#[class(base=Sprite2D)]` becomes `Base<Sprite2D>`.
+     - `T` must match the declared base class, e.g. `#[class(base=Sprite2D)]` implies `Base<Sprite2D>`.
    - The name can be freely chosen. Here it's `sprite`, but `base` is also a common convention.
    - You do not _have to_ declare this field. If it is absent, you cannot access the base object from within `self`.
      This is often not a problem, e.g. in data bundles inheriting `RefCounted`.
@@ -329,7 +284,7 @@ Use version control (git) to check for unwanted changes in `.tscn` files.
 ```
 
 
-#### Method declaration
+### Method declaration
 
 Now let's add some logic. We start with overriding the `init` method, also known as the constructor.
 This corresponds to GDScript's `_init()` function.
@@ -385,8 +340,8 @@ impl Sprite2DVirtual for Player {
 }
 ```
 
-GDScript uses property syntax here; Rust requires explicit method calls instead. Also, access to base class methods -- such as `rotate()` in
-this example -- is done via the `#[base]` field.
+GDScript uses property syntax here; Rust requires explicit method calls instead. Also, access to base class methods -- such as `rotate()`
+in this example -- is done via the `#[base]` field.
 
 This is a point where you can compile your code, launch Godot and see the result. The sprite should rotate at a constant speed.
 
@@ -440,8 +395,8 @@ The result should be a sprite that rotates with an offset.
 
 ### Custom Rust APIs
 
-Say you want to add some functionality to your `Player` class, which can be called from GDScript. For this, you have a separate `impl` block,
-again annotated with `#[godot_api]`. However, this time we are using an _inherent_ `impl` (i.e. without a trait name).
+Say you want to add some functionality to your `Player` class, which can be called from GDScript. For this, you have a separate `impl` block, again
+annotated with `#[godot_api]`. However, this time we are using an _inherent_ `impl` (i.e. without a trait name).
 
 Concretely, we add a function to increase the speed, and a signal to notify other objects of the speed change.
 
@@ -474,14 +429,14 @@ That's it for the _Hello World_ tutorial! The following chapters will go into mo
 [api-engine]: https://godot-rust.github.io/docs/gdext/master/godot/engine/index.html
 [api-extensionlibrary]: https://godot-rust.github.io/docs/gdext/master/godot/prelude/trait.ExtensionLibrary.html
 [api-godot]: https://godot-rust.github.io/docs/gdext/master/godot/index.html
-[api-sprite2d]: https://godot-rust.github.io/docs/gdext/master/godot/engine/struct.Sprite2D.html
 [api-prelude]: https://godot-rust.github.io/docs/gdext/master/godot/prelude/index.html
-[ref-resource-paths]: https://docs.godotengine.org/en/stable/tutorials/scripting/resources.html#external-vs-built-in
+[api-sprite2d]: https://godot-rust.github.io/docs/gdext/master/godot/engine/struct.Sprite2D.html
+[compatibility]: ../toolchain/compatibility.md
+[godot-build-targets]: https://docs.godotengine.org/en/stable/tutorials/scripting/gdextension/gdextension_cpp_example.html#using-the-gdextension-module
+[godot-resource-paths]: https://docs.godotengine.org/en/stable/tutorials/scripting/resources.html#external-vs-built-in
+[img-sprite-moving]: https://docs.godotengine.org/en/stable/_images/scripting_first_script_rotating_godot.gif
+[img-sprite-rotating]: https://docs.godotengine.org/en/stable/_images/scripting_first_script_godot_turning_in_place.gif
+[issue-no-reload]: https://github.com/godotengine/godot/issues/66231
 [tutorial-begin]: https://docs.godotengine.org/en/stable/getting_started/step_by_step/scripting_first_script.html
 [tutorial-full-script]: https://docs.godotengine.org/en/stable/getting_started/step_by_step/scripting_first_script.html#complete-script
-[img-sprite-rotating]: https://docs.godotengine.org/en/stable/_images/scripting_first_script_godot_turning_in_place.gif
-[img-sprite-moving]: https://docs.godotengine.org/en/stable/_images/scripting_first_script_rotating_godot.gif
-[issue-no-reload]: https://github.com/godotengine/godot/issues/66231
-"A screenshot of the GUI of the Godot project manager about to create a new project"
 [wikipedia-ffi]: https://en.wikipedia.org/wiki/Foreign_function_interface
-"Foreign Function Interface"

--- a/src/intro/hello-world.md
+++ b/src/intro/hello-world.md
@@ -4,6 +4,7 @@
   ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -->
 
+
 # Hello World
 
 This page shows you how to develop your own small extension library and load it from Godot.
@@ -15,22 +16,105 @@ It is recommended to follow that alongside this tutorial, in case you're interes
 <!-- toc -->
 
 
-## Godot project
+## Connecting Godot and Rust
 
-Open the Godot project manager and create a blank Godot 4 project. Run the default scene to make sure everything is working.
-Save the changes and consider versioning each step of the tutorial in Git.
+First things first.  
+For the following objective, we'll first make
 
-Once you have a Godot project, you can register GDExtension libraries that it should use. These libraries are called _extensions_
-and loaded during Godot engine startup -- both when opening the editor and when launching your game. The registration requires two files.
+- A Cargo crate of your own;
+- A Godot project created;
+
+You can very much start from an already existing Godot project. Here we'll start from scratch for the sake of completeness.
+
+
+### Creating the Godot Project
+
+For this example we're going to create each of the items separated into neighboring folders in the same parent folder. You'll be able to choose
+locations of your own as we progress. Let's start by creating a blank Godot project if you haven't already.
+
+Not much to do here yet, we'll come back to it later.
+
+
+### Creating the Rust Cargo crate
+
+To create a Cargo crate, have your terminal open, navigate to your desired folder and then call `cargo` to create it by typing:
+
+```bash
+cargo new "your_crate_name" --lib
+```
+
+The argument `--lib` will tell `cargo` to create the package from a Library template. From there, we're going to configure it in the file which stores
+its metadata, `Cargo.toml`. This file stores the information we know of the library package and what it uses in order to work with it.
+
+Open `Cargo.toml` in your favorite text editor and edit it as the following:
+
+```toml
+[package]
+name = "rust_project" # Will appear in the filename of the dynamic Rust library you compile.
+version = "0.1.0" # version of your library (your criteria)
+edition = "2021" # Rust edition version (remains unchanged)
+
+[lib]
+crate-type = ["cdylib"] # defines the kind of library it will become
+
+[dependencies] # lists what your own library needs in order to function
+godot = { git = "https://github.com/godot-rust/gdext", branch = "master" }
+```
+
+
+#### Why "`cdylib`"?
+<!-- editors note: sole reason this header's here is because this marks a quick spot to go back to later on,
+specially if a new reader is just scrolling by around the book. -->
+
+The `cdylib` crate type is a bit unusual in Rust. Instead of building a binary (`bin`, application) or a library to be utilized by other Rust code
+(`lib`), we create a _dynamic_ library, exposing an interface in the C programming language. This dynamic library is loaded by Godot at runtime,
+through the GDExtension interface.
+
+```admonish note
+The main crate of gdext is called `godot`. At this point, it is still hosted on GitHub; in the future, it will be published to crates.io. To fetch the
+latest changes, you can regularly run a `cargo update` (possibly breaking). Keep your `Cargo.lock` file under version control, so that it's easy to
+revert updates.
+```
+
+To compile each iteration of the extension as you write your code, you can use `cargo` as you normally do with any other Rust project:
+
+```bash
+cargo build
+```
+
+This should output to `rust_project/target/debug/` at least one variation of a compiled library depending on your setup. For instance,
+`librust_project.so` is created if you're on Linux:
+
+```log
+$ cargo build
+   Compiling godot4-prebuilt v0.0.0 (https://github.com/godot-rust/godot4-prebuilt?branch=4.1.1#fca6897d)
+   Compiling proc-macro2 v1.0.69
+   [...]
+   Compiling godot v0.1.0 (https://github.com/godot-rust/gdext?branch=master#66df8f47)
+   Compiling rust_project v0.1.0 (/home/wilker/Documentos/Projects/Programming/Godot/Tutorial/rust_project)
+    Finished dev [unoptimized + debuginfo] target(s) in 1m 46s
+
+$ ls -l
+╭───┬─────────────────────────────────┬──────┬─────────┬────────────────╮
+│ # │              name               │ type │  size   │    modified    │
+├───┼─────────────────────────────────┼──────┼─────────┼────────────────┤
+│ 0 │ target/debug/build              │ dir  │   648 B │ 2 minutes ago  │
+│ 1 │ target/debug/deps               │ dir  │  3.8 KB │ now            │
+│ 2 │ target/debug/examples           │ dir  │     0 B │ 2 minutes ago  │
+│ 3 │ target/debug/incremental        │ dir  │    52 B │ 16 seconds ago │
+│ 4 │ target/debug/librust_project.d  │ file │   190 B │ now            │
+│ ⮞ │ target/debug/librust_project.so │ file │ 62.6 MB │ now            │
+╰───┴─────────────────────────────────┴──────┴─────────┴────────────────╯
+```
 
 
 ### `.gdextension` file
 
-First, add `res://HelloWorld.gdextension`, which is the equivalent of `.gdnlib` for GDNative.
+The job of this file is to provide Godot with pointers to a library that is compiled elsewhere. We're going to use it to connect Godot to your
+compiled library so it can be used within the context of your Godot project.
 
-The `[configuration]` section should be copied as-is.  
-The `[libraries]` section should be updated to match the paths of your dynamic Rust libraries.
-`{myCrate}` can be replaced with the name of your crate.
+First, add an empty `.gdextension` file somewhere in your project folder, which is the equivalent of `.gdnlib` for GDNative. In this case we're
+creating `res://HelloWorld.gdextension` in the root folder of the project. Following along,
 
 ```ini
 [configuration]
@@ -38,18 +122,52 @@ entry_symbol = "gdext_rust_init"
 compatibility_minimum = 4.1
 
 [libraries]
-linux.debug.x86_64 = "res://../rust/target/debug/lib{myCrate}.so"
-linux.release.x86_64 = "res://../rust/target/release/lib{myCrate}.so"
-windows.debug.x86_64 = "res://../rust/target/debug/{myCrate}.dll"
-windows.release.x86_64 = "res://../rust/target/release/{myCrate}.dll"
-macos.debug = "res://../rust/target/debug/lib{myCrate}.dylib"
-macos.release = "res://../rust/target/release/lib{myCrate}.dylib"
-macos.debug.arm64 = "res://../rust/target/debug/lib{myCrate}.dylib"
-macos.release.arm64 = "res://../rust/target/release/lib{myCrate}.dylib"
+linux.debug.x86_64 = "res://../{myCrate}/target/debug/lib{myCrate}.so"
 ```
 
+- The `[configuration]` section should be copied as-is.
+  - The name `gdext_rust_init` for the entry point is provided by **godot-rust**
+    and is required for the extension to initialize;
+  - `compatibility_minimum` is the minimum version of **Godot** required by your extension to work.
+    Opening the project with a version of Godot lower than this will prevent your extension from running;
+- The `[libraries]` section should be updated to match the paths of your dynamic Rust libraries.
+  - `linux.debug.x86_64` is the [**target build**](#other-possible-target-paths) of the **Godot** project.
+  - `{myCrate}` should be replaced with the name of your compiled file. For instance,
+    `librust_project.so` from the name of the library we compiled earlier;
+
 ```admonish note
-For exporting your project, you'll need to use paths inside `res://`.
+For exporting your project, you'll need to use paths inside `res://`. This prefix represents the path to your files **relative to the root folder of
+your project**. You can learn more about Godot's resource paths [here][ref-resource-paths].
+```
+
+
+#### Other possible target paths
+
+The following is a list of other possible paths depending on the target of your library. You can copy them as-is for this example, replacing
+`{myCrate}` with the name of your actual library:
+
+```ini
+[configuration] # same as before
+entry_symbol = "gdext_rust_init"
+compatibility_minimum = 4.1
+
+[libraries]
+linux.debug.x86_64 =     "res://../{myCrate}/target/debug/lib{myCrate}.so"
+linux.release.x86_64 =   "res://../{myCrate}/target/release/lib{myCrate}.so"
+windows.debug.x86_64 =   "res://../{myCrate}/target/debug/{myCrate}.dll"
+windows.release.x86_64 = "res://../{myCrate}/target/release/{myCrate}.dll"
+macos.debug =            "res://../{myCrate}/target/debug/lib{myCrate}.dylib"
+macos.release =          "res://../{myCrate}/target/release/lib{myCrate}.dylib"
+macos.debug.arm64 =      "res://../{myCrate}/target/debug/lib{myCrate}.dylib"
+macos.release.arm64 =    "res://../{myCrate}/target/release/lib{myCrate}.dylib"
+```
+
+The `..` is a pointer to a parent folder of the end path.
+e.g Godot will look in a path relative to this project directory's parent folder.
+
+
+```admonish tip
+You can also employ the use of symbolic links and git submodules and then treat those as regular folders and files. Godot reads those just fine too! 
 ```
 
 ```admonish note
@@ -67,41 +185,18 @@ If not, you can also manually create it, simply containing the Godot path to you
 ```text
 res://HelloWorld.gdextension
 ```
+<!-- TODO: explain further the necessity and functionality of the extension_list.cfg -->
 
 
-## Cargo project
-
-In your terminal, create a new Cargo project with your chosen crate name:
-
-```bash
-cargo new {myCrate} --lib
-```
-
-Then, open Cargo.toml and add the following:
-
-```toml
-[lib]
-crate-type = ["cdylib"]
-
-[dependencies]
-godot = { git = "https://github.com/godot-rust/gdext", branch = "master" }
-```
-
-The `cdylib` crate type is a bit unusual in Rust. Instead of building a binary (`bin`, application) or library to be consumed by other Rust
-code (`lib`), we create a _dynamic_ library exposing an interface in the _C_ programming language. This dynamic library is loaded by
-Godot at runtime, through the GDExtension interface.
-
-The main crate of gdext is called `godot`. At this point, it is still hosted on GitHub; in the future, it will be published to crates.io.
-To fetch the latest changes, you can regularly run a `cargo update` (possibly breaking). Keep your `Cargo.lock` file under version control,
-so that it's easy to revert updates.
+## Implementing your extension and your first Node
 
 
-## Rust entry point
+### Rust entry point
 
-Our C library needs to expose an _entry point_ to Godot: a C function that can be called through the GDExtension.
-Setting this up requires quite some low-level FFI code, which is why gdext abstracts it for you.
+[Like mentioned earlier](#why-cdylib), our compiled C library needs to expose an _entry point_ to Godot: a C function that can be called through
+the GDExtension. Setting this up requires quite some low-level [FFI][wikipedia-ffi] code, which is why gdext abstracts it for you.
 
-In your `lib.rs`, add the following:
+In your `lib.rs`, replace the template with the following:
 
 ```rust
 use godot::prelude::*;
@@ -114,24 +209,71 @@ unsafe impl ExtensionLibrary for MyExtension {}
 
 There are multiple things going on here:
 
-1. Import the `prelude` module from the `godot` crate. This module contains the most common symbols in the gdext API.
+1. Place the [`prelude`][api-prelude] module from the [`godot`][api-godot] crate into scope.
+   This module contains the most common symbols in the gdext API.
 2. Define a struct called `MyExtension`. This is just a type tag without data or methods, you can name it however you like.
-3. Implement the `ExtensionLibrary` trait for our type, and mark it with the `#[gdextension]` attribute.
+3. Implement the [`ExtensionLibrary`][api-extensionlibrary] trait for our type, and mark it with the `#[gdextension]` attribute.
 
 The last point declares the actual GDExtension entry point, and the proc-macro attribute takes care of the low-level details.
 
 
-## Creating a Rust class
+#### "Does it load though?"
+
+If you want to see Godot loading your extension, you can override `on_level_init(InitLevel)` from the
+[`ExtensionLibrary`][api-extensionlibrary] trait like so:
+
+```rust
+use godot::prelude::*;
+
+struct MyExtension;
+
+#[gdextension]
+unsafe impl ExtensionLibrary for MyExtension {
+    fn on_level_init(level: InitLevel) {
+        godot_print!("Hello Library!");
+
+        godot_print!("Initialization level: {:?}", level);
+    }
+}
+```
+
+After `cargo build`, Godot should display the following messages when running it from the command line:
+
+
+```log
+Godot/Tutorial/GodotProject
+$ godot4 -e
+Initialize GDExtension API for Rust: Godot Engine v4.2.beta1.official
+Hello Library!
+Initialization level: Core
+Godot Engine v4.2.beta1.official.b1371806a - https://godotengine.org
+Hello Library!
+Initialization level: Servers
+Vulkan API 1.3.246 - Forward+ - Using Vulkan Device #0: AMD - AMD Radeon Vega 8 Graphics (RADV RAVEN)
+
+Hello Library!
+Initialization level: Scene
+Hello Library!
+Initialization level: Editor
+```
+
+```admonish note
+These messages will most likely not show up unless you're either launching [Godot editor from your command line][godot-command-line] by using
+`godot -e` like in this example, or making your gdextension file visible for the first time in Godot while opened.
+```
+
+
+### Your first Rust class
 
 Now, let's write Rust code to define a _class_ that can be used in Godot.
 
-Every class inherits an existing Godot-provided class (its _base class_ or just _base_).
-Rust does not natively support inheritance, but the gdext API emulates it to a certain extent.
+Every class inherits an existing Godot-provided class (its _base class_ or just _base_). Rust does not natively support inheritance, but the gdext API
+emulates it to a certain extent.
 
 
-### Class declaration
+#### Class declaration
 
-In this example, we declare a class called `Player`, which inherits [`Sprite2D`][sprite2d-api] (a node type):
+In this example, we declare a class called `Player`, which inherits [`Sprite2D`][api-sprite2d] (a node type):
 
 ```rust
 use godot::prelude::*;
@@ -150,28 +292,30 @@ struct Player {
 
 Let's break this down.
 
-1. The gdext prelude contains the most common symbols. Less frequent classes are located in the `engine` module.
+1. The gdext prelude contains the most common symbols. Less frequent classes are located in the [`engine`][api-engine] module.
 
 2. The `#[derive]` attribute registers `Player` as a class in the Godot engine.
-   See [API docs][derive-godotclass] for details about `#[derive(GodotClass)]`.
+   See [API docs][api-derive-godotclass] for details about `#[derive(GodotClass)]`.
 
    ```admonish info
    `#[derive(GodotClass)]` _automatically_ registers the class -- you don't need an explicit 
    `add_class()` registration call, or a `.gdns` file as it was the case with GDNative.
    
-   You will however need to restart the Godot editor to take effect.
+   You will, however, need to restart the Godot editor for it to take effect.
    ```
 
-3. The optional `#[class]` attribute configures how the class is registered. In this case, we specify that `Player` inherits Godot's
+3. We define two fields `speed` and `angular_speed` for the logic. These are regular Rust fields, no magic involved. More about their use later.
+
+4. The optional `#[class]` attribute configures how the class is registered. In this case, we specify that `Player` inherits Godot's
    `Sprite2D` class. If you don't specify the `base` key, the base class will implicitly be `RefCounted`, just as if you omitted the
    `extends` keyword in GDScript.
 
-4. We define two fields `speed` and `angular_speed` for the logic. These are regular Rust fields, no magic involved. More about their use later.
 
 5. The `#[base]` attribute declares the `sprite` field, which allows `self` to access the base instance (via composition, as Rust does not have
    native inheritance).
 
    - The field must have type `Base<T>`.
+     - `T` must match the declared base class, e.g. `Sprite2D` for `#[class(base=Sprite2D)]` becomes `Base<Sprite2D>`.
    - The name can be freely chosen. Here it's `sprite`, but `base` is also a common convention.
    - You do not _have to_ declare this field. If it is absent, you cannot access the base object from within `self`.
      This is often not a problem, e.g. in data bundles inheriting `RefCounted`.
@@ -185,7 +329,7 @@ Use version control (git) to check for unwanted changes in `.tscn` files.
 ```
 
 
-### Method declaration
+#### Method declaration
 
 Now let's add some logic. We start with overriding the `init` method, also known as the constructor.
 This corresponds to GDScript's `_init()` function.
@@ -246,17 +390,17 @@ this example -- is done via the `#[base]` field.
 
 This is a point where you can compile your code, launch Godot and see the result. The sprite should rotate at a constant speed.
 
-![rotating sprite](https://docs.godotengine.org/en/stable/_images/scripting_first_script_godot_turning_in_place.gif)
+![rotating sprite][img-sprite-rotating]
 
 ```admonish tip
- **Launching the Godot application**
- 
-While it's possible to open the Godot editor and press the launch button every time you made a change in Rust, this is not the most
-efficient workflow. Unfortunately there is [a GDExtension limitation][no-reload] that prevents recompilation while the editor is open 
- (at least on Windows systems -- it tends to work better on Linux and macOS).
- 
- However, if you don't need to modify anything in the editor itself, you can launch Godot from the command line or even your IDE.
- Check out the [command-line tutorial][godot-command-line] for more information.
+**Launching the Godot application**
+
+While it's possible to open the Godot editor and press the launch button every time you made a change in Rust, this is not the most efficient
+workflow. Unfortunately there is [a GDExtension limitation][issue-no-reload] that prevents recompilation while the editor is open 
+(at least on Windows systems -- it tends to work better on Linux and macOS).
+
+However, if you don't need to modify anything in the editor itself, you can launch Godot from the command line or even your IDE.
+Check out the [command-line tutorial][godot-command-line] for more information.
 ```
 
 We now add a translation component to the sprite, following [the upstream tutorial][tutorial-full-script].
@@ -291,7 +435,7 @@ impl Sprite2DVirtual for Player {
 
 The result should be a sprite that rotates with an offset.
 
-![rotating translated sprite](https://docs.godotengine.org/en/stable/_images/scripting_first_script_rotating_godot.gif)
+![rotating translated sprite][img-sprite-moving]
 
 
 ### Custom Rust APIs
@@ -326,9 +470,18 @@ API attributes typically follow the GDScript keyword names: `class`, `func`, `si
 That's it for the _Hello World_ tutorial! The following chapters will go into more detail about the various features that gdext provides.
 
 
-[derive-godotclass]: https://godot-rust.github.io/docs/gdext/master/godot/prelude/derive.GodotClass.html
-[godot-command-line]: https://docs.godotengine.org/en/stable/tutorials/editor/command_line_tutorial.html
-[no-reload]: https://github.com/godotengine/godot/issues/66231
-[sprite2d-api]: https://godot-rust.github.io/docs/gdext/master/godot/engine/struct.Sprite2D.html
+[api-derive-godotclass]: https://godot-rust.github.io/docs/gdext/master/godot/prelude/derive.GodotClass.html
+[api-engine]: https://godot-rust.github.io/docs/gdext/master/godot/engine/index.html
+[api-extensionlibrary]: https://godot-rust.github.io/docs/gdext/master/godot/prelude/trait.ExtensionLibrary.html
+[api-godot]: https://godot-rust.github.io/docs/gdext/master/godot/index.html
+[api-sprite2d]: https://godot-rust.github.io/docs/gdext/master/godot/engine/struct.Sprite2D.html
+[api-prelude]: https://godot-rust.github.io/docs/gdext/master/godot/prelude/index.html
+[ref-resource-paths]: https://docs.godotengine.org/en/stable/tutorials/scripting/resources.html#external-vs-built-in
 [tutorial-begin]: https://docs.godotengine.org/en/stable/getting_started/step_by_step/scripting_first_script.html
 [tutorial-full-script]: https://docs.godotengine.org/en/stable/getting_started/step_by_step/scripting_first_script.html#complete-script
+[img-sprite-rotating]: https://docs.godotengine.org/en/stable/_images/scripting_first_script_godot_turning_in_place.gif
+[img-sprite-moving]: https://docs.godotengine.org/en/stable/_images/scripting_first_script_rotating_godot.gif
+[issue-no-reload]: https://github.com/godotengine/godot/issues/66231
+"A screenshot of the GUI of the Godot project manager about to create a new project"
+[wikipedia-ffi]: https://en.wikipedia.org/wiki/Foreign_function_interface
+"Foreign Function Interface"

--- a/src/intro/index.md
+++ b/src/intro/index.md
@@ -11,8 +11,7 @@ This chapter guides you through the process of setting up **gdext** and developi
 
 ```admonish note
 To read this book, we assume intermediate Rust knowledge. If you are new to Rust, reading the [Rust Book][rust-book] first is highly encouraged.
-You won't need to know 100% of the language, but you should know basic concepts (type system, generics,
-traits, borrow checking, safety).
+You won't need to know 100% of the language, but you should know basic concepts (type system, generics, traits, borrow checking, safety).
 
 Some familiarity with Godot is also necessary, although it is possible to learn gdext together with Godot. 
 However, we won't reiterate basic Godot concepts -- so if you choose that approach, we recommend to read

--- a/src/intro/index.md
+++ b/src/intro/index.md
@@ -10,8 +10,8 @@ This chapter guides you through the process of setting up **gdext** and developi
 
 
 ```admonish note
-To read this book, we assume intermediate Rust knowledge. If you are new to Rust, reading the [Rust Book][rust-book] first
-is highly encouraged. You won't need to know 100% of the language, but you should know basic concepts (type system, generics,
+To read this book, we assume intermediate Rust knowledge. If you are new to Rust, reading the [Rust Book][rust-book] first is highly encouraged.
+You won't need to know 100% of the language, but you should know basic concepts (type system, generics,
 traits, borrow checking, safety).
 
 Some familiarity with Godot is also necessary, although it is possible to learn gdext together with Godot. 

--- a/src/intro/setup.md
+++ b/src/intro/setup.md
@@ -6,7 +6,7 @@
 
 # Setup
 
-To use gdext, we need a few technologies.
+To use gdext, we need a few items.
 
 
 ## Godot Engine
@@ -17,15 +17,59 @@ For the rest of the tutorial, we assume that you have Godot 4 installed and avai
 - in your `PATH` as `godot4`,
 - or an environment variable called `GODOT4_BIN`, containing the path to the Godot executable.
 
-Binaries of Godot 4 can be downloaded [from the official website][godot-download].
 
+### Godot from pre-built binaries
+
+Binaries of Godot 4 can be downloaded [from the official website][godot-download].
+For beta and older versions, you can also check the [Archive][godot-download-archive].
+
+
+### Installing Godot via command-line
+
+```bash
+#-- Linux --#
+# For Ubuntu or Debian-based distros
+apt install godot
+
+# For Fedora/RHEL
+dnf install godot
+
+# Distro-independent through Flatpak
+flatpak install flathub org.godotengine.Godot
+
+
+#-- Windows --#
+# Windows installations can be made through WinGet
+winget install --id=GodotEngine.GodotEngine -e
+
+
+#-- macOS --#
+brew install godot
+```
+
+```admonish note
 If you plan to target Godot versions different from the latest stable release, please read [Compatibility and stability][compatibility].
+```
 
 
 ## Rust
 
 [rustup] is the recommended way to install the Rust toolchain, including the compiler, standard library and Cargo (the package manager).
 This page contains installation instructions for your platform.
+
+
+### Installing Rustup via command-line
+
+```bash
+#-- Linux (distro-independent) --#
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+#-- Windows --#
+winget install --id=Rustlang.Rustup  -e
+
+#-- macOS --#
+brew install rustup
+```
 
 After installation of rustup and the `stable` toolchain, check that they were installed properly:
 
@@ -39,6 +83,12 @@ cargo -V
 ```
 
 If you use Windows, check out [Working with Rust on Windows][rustup-windows].
+
+---
+
+From this point on, you're ready to beguin using the library.
+
+---
 
 
 ## LLVM
@@ -64,7 +114,8 @@ clang -v
 
 
 [compatibility]: ../advanced/compatibility.md
-[godot-download]: https://godotengine.org/download
+[godot-download]: https://godotengine.org/download/
+[godot-download-archive]: https://godotengine.org/download/archive/
 [godot-version]: ../advanced/godot-version.md
 [llvm-bindgen]: https://rust-lang.github.io/rust-bindgen/requirements.html
 [llvm]: https://releases.llvm.org

--- a/src/intro/setup.md
+++ b/src/intro/setup.md
@@ -6,7 +6,7 @@
 
 # Setup
 
-To use gdext, we need a few items.
+To use gdext, we need a few technologies.
 
 
 ## Godot Engine
@@ -27,7 +27,7 @@ For beta and older versions, you can also check the [Archive][godot-download-arc
 ### Installing Godot via command-line
 
 ```bash
-#-- Linux --#
+# --- Linux ---
 # For Ubuntu or Debian-based distros
 apt install godot
 
@@ -38,12 +38,12 @@ dnf install godot
 flatpak install flathub org.godotengine.Godot
 
 
-#-- Windows --#
+# --- Windows ---
 # Windows installations can be made through WinGet
 winget install --id=GodotEngine.GodotEngine -e
 
 
-#-- macOS --#
+# --- macOS ---
 brew install godot
 ```
 
@@ -61,13 +61,13 @@ This page contains installation instructions for your platform.
 ### Installing Rustup via command-line
 
 ```bash
-#-- Linux (distro-independent) --#
+# Linux (distro-independent)
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
-#-- Windows --#
+# Windows
 winget install --id=Rustlang.Rustup  -e
 
-#-- macOS --#
+# macOS
 brew install rustup
 ```
 
@@ -83,12 +83,6 @@ cargo -V
 ```
 
 If you use Windows, check out [Working with Rust on Windows][rustup-windows].
-
----
-
-From this point on, you're ready to beguin using the library.
-
----
 
 
 ## LLVM


### PR DESCRIPTION
As discussed in the Discord server, the main problem with the tutorials and introductions included within the book is that it is hard to even grasp what even is an Extension in the context of Godot. Going back to read it a couple of times, the culprit for that is that it includes too much of the preparation and almost none of the process. Basically a lot of "You have to do that", "Do this before you begin using", "This is the difference compared to a version you might have never used", but too little of "This is how it works, here's how to set it up". 

While sure, assuming the reader might have the basic or or moderate understanding of the Rust language and its tools is reasonable to get the message delivered quickly, that does not exempt the book from the necessity of splitting the seemingly obvious details of the process to enable the explanation of its nuances, so keeping variations of "x is y+1 is 11" and having its variations as but a second thought will more often than not wrap it around into complicating it all again, both the learning process as well as the troubleshooting process.

This series of commits is aimed at easing the learning curve to new readers, both those new to Godot in general as well as those who may have just started learning Rust. The ideal scenario is that it will succeed in making a portion of the necessary information understandable at a glance for those who would prefer to scroll faster than reasonable. If all goes well, this should help other people to improve the explanations of the nuances that may affect the inclusion of the library into new and ongoing projects.

Thank you for reading :heart:

###### ps: yes it does have a diagram in it. sorry @Bromeon 