### PR TITLE
Update `Gd::with_base` method recommendation to `Gd::from_init_fn`

### DIFF
--- a/src/intro/objects.md
+++ b/src/intro/objects.md
@@ -103,7 +103,7 @@ constructor list.
 
 ```admonish note
 `init` cannot take custom parameters. There are however a few ways around that.
-- From Rust code, simply call [`Gd::with_base()`][gd-with-base].
+- From Rust code, simply call [`Gd::from_init_fn()`][from-init-fn].
 - From GDScript, you can write a custom method such as `post_init()`, which late-initializes fields. This will reduce type safety though,
   needing `Option` for fields whose values aren't available at initialization time.
 - Another alternative is to use a third-party class such as `PlayerFactory`, which has a method accepting parameters and returning a
@@ -122,5 +122,6 @@ Keep in mind that node classes in Godot are manually-managed. When outside the s
 using [`free()`][gd-free].
 
 
+[from-init-fn]: https://godot-rust.github.io/docs/gdext/master/godot/obj/struct.Gd.html#method.from_init_fn
 [gd-free]: https://godot-rust.github.io/docs/gdext/master/godot/obj/struct.Gd.html#method.free
 [gd]: https://godot-rust.github.io/docs/gdext/master/godot/obj/struct.Gd.html

--- a/src/intro/objects.md
+++ b/src/intro/objects.md
@@ -103,7 +103,7 @@ constructor list.
 
 ```admonish note
 `init` cannot take custom parameters. There are however a few ways around that.
-- From Rust code, simply call [`Gd::from_init_fn()`][from-init-fn].
+- From Rust code, simply call [`Gd::from_init_fn()`][gd-from-init-fn].
 - From GDScript, you can write a custom method such as `post_init()`, which late-initializes fields. This will reduce type safety though,
   needing `Option` for fields whose values aren't available at initialization time.
 - Another alternative is to use a third-party class such as `PlayerFactory`, which has a method accepting parameters and returning a
@@ -122,6 +122,6 @@ Keep in mind that node classes in Godot are manually-managed. When outside the s
 using [`free()`][gd-free].
 
 
-[from-init-fn]: https://godot-rust.github.io/docs/gdext/master/godot/obj/struct.Gd.html#method.from_init_fn
+[gd-from-init-fn]: https://godot-rust.github.io/docs/gdext/master/godot/obj/struct.Gd.html#method.from_init_fn
 [gd-free]: https://godot-rust.github.io/docs/gdext/master/godot/obj/struct.Gd.html#method.free
 [gd]: https://godot-rust.github.io/docs/gdext/master/godot/obj/struct.Gd.html


### PR DESCRIPTION
that thing I mentioned in the `#contrib-gdext` discord channel :P

Also added a reference at the bottom of the file (it used to be a broken reference)
![image](https://github.com/godot-rust/book/assets/35111165/3136eadb-5e91-4ec4-af5c-8017c99f1fc3)
