### PR TITLE
Include oxipng in CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,10 +17,11 @@ env:
   MDBOOK_TOC_VERSION: "0.13.0"
   MDBOOK_ADMONISH_VERSION: "1.10.1"
   MDBOOK_BIN: "/tmp/mdbook-bin"
+  OXIPNG_VERSION: "9.0.0"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write # git push for oxipng
   pages: write
   id-token: write
 
@@ -30,7 +31,7 @@ jobs:
 
     steps:
     - name: "Checkout"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Note: actions-rs/install@v0.1 was considered, but a full 'cargo install' is unnecessarily slow and the cache mechanism is not reliable
     # (error "Unable to download mdbook == 0.4.14 from the tool cache: Error: Unexpected HTTP response: 403")
@@ -67,7 +68,7 @@ jobs:
   markdown-lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: "Install markdownlint-cli2"
       run: npm install -g markdownlint-cli2
@@ -86,7 +87,7 @@ jobs:
   license-guard:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Check license headers"
         uses: apache/skywalking-eyes/header@v0.5.0
@@ -99,11 +100,32 @@ jobs:
           mode: check
 #          mode: fix
 
-#      - name: "Commit changes"
-#        uses: EndBug/add-and-commit@v9
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        with:
-#          author_name: 'Godot-Rust Automation'
-#          author_email: 'actions@github.com'
-#          message: 'Auto-apply license headers'
+
+  oxipng:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: "Run oxipng to reduce PNG sizes"
+      run: |
+        wget https://github.com/shssoichiro/oxipng/releases/download/v${OXIPNG_VERSION}/oxipng-${OXIPNG_VERSION}-x86_64-unknown-linux-musl.tar.gz \
+        -O /tmp/oxipng.tar.gz
+        
+        tar -xvzf /tmp/oxipng.tar.gz -C /tmp
+        mv /tmp/oxipng-${OXIPNG_VERSION}-x86_64-unknown-linux-musl/oxipng ./oxipng
+        chmod +x ./oxipng
+        
+        ./oxipng --version
+        ./oxipng --strip safe --alpha -r src
+
+    # See https://github.com/EndBug/add-and-commit#add--commit.
+    - name: "Commit changes"
+      uses: EndBug/add-and-commit@v9
+      with:
+        author_name: 'Godot-Rust Automation'
+        author_email: '115185599+GodotRust@users.noreply.github.com'
+        message: 'Auto-reduce PNG sizes'
+        add: 'src/**/*.png'


### PR DESCRIPTION
Runs the following command, which shrinks size of PNGs:
```bash
oxipng --strip safe --alpha -r src
```
See [ReadMe](https://github.com/shssoichiro/oxipng#usage) for details about oxipng.

After that, a commit should be pushed to the same branch (of the PR). In the past I had some issues with permission to other people's branches, so might need some monitoring to see if it works.