### PR TITLE
Add instructions to use Cargo to set GODOT4_BIN to relative path.

### DIFF
--- a/src/toolchain/godot-version.md
+++ b/src/toolchain/godot-version.md
@@ -56,7 +56,7 @@ location.
 You can do this by configuring Cargo to set `GODOT4_BIN` to a relative path for you, in `.cargo/config.toml`.
 
 In the root of your Rust project, create `.cargo/config.toml` with the example content shown below, modifying the editor path as needed to find
-your binary. The path you set will be resolved relative to the location of the `.cargo` directory.
+your binary. The path you set will be resolved relatively to the location of the `.cargo` directory.
 
 ```toml
 [env]

--- a/src/toolchain/godot-version.md
+++ b/src/toolchain/godot-version.md
@@ -49,8 +49,8 @@ Consult the [setup page][setup-llvm] for more information.
 
 ### Setting `GODOT4_BIN` to a relative path
 
-If you have multiple Godot workspaces on a machine, you may want a workspace-independent method of setting the `GODOT4_BIN` environment variable
-so the matching Godot editor binary for that workspace is always used in the build process, without having to set `GODOT4_BIN` differently for each
+If you have multiple Godot workspaces on a machine, you may want a workspace-independent method of setting the `GODOT4_BIN` environment variable.
+This way, the matching Godot editor binary for that workspace is always used in the build process, without having to set `GODOT4_BIN` differently for each
 location.
 
 You can do this by configuring Cargo to set `GODOT4_BIN` to a relative path for you, in `.cargo/config.toml`.

--- a/src/toolchain/godot-version.md
+++ b/src/toolchain/godot-version.md
@@ -47,7 +47,7 @@ Note that this requires the `bindgen`, as such you may need to install the LLVM 
 Consult the [setup page][setup-llvm] for more information.
 
 
-### Setting `GODOT4_BIN` to a Relative Path
+### Setting `GODOT4_BIN` to a relative path
 
 If you have multiple Godot workspaces on a machine, you may want a workspace-independent method of setting the `GODOT4_BIN` environment variable
 so the matching Godot editor binary for that workspace is always used in the build process, without having to set `GODOT4_BIN` differently for each

--- a/src/toolchain/godot-version.md
+++ b/src/toolchain/godot-version.md
@@ -50,8 +50,8 @@ Consult the [setup page][setup-llvm] for more information.
 ### Setting `GODOT4_BIN` to a relative path
 
 If you have multiple Godot workspaces on a machine, you may want a workspace-independent method of setting the `GODOT4_BIN` environment variable.
-This way, the matching Godot editor binary for that workspace is always used in the build process, without having to set `GODOT4_BIN` differently for each
-location.
+This way, the matching Godot editor binary for that workspace is always used in the build process, without having to set `GODOT4_BIN` differently
+for each location.
 
 You can do this by configuring Cargo to set `GODOT4_BIN` to a relative path for you, in `.cargo/config.toml`.
 
@@ -74,4 +74,3 @@ See [The Cargo Book](https://doc.rust-lang.org/cargo/reference/config.html) for 
 [Compatibility and stability]: compatibility.md
 [compat-guarantees]: compatibility.md#current-guarantees
 [setup-llvm]: ../intro/setup.md#llvm
-

--- a/src/toolchain/godot-version.md
+++ b/src/toolchain/godot-version.md
@@ -46,13 +46,17 @@ Note that we do not give any support or compatibility guarantees for custom-buil
 Note that this requires the `bindgen`, as such you may need to install the LLVM toolchain.
 Consult the [setup page][setup-llvm] for more information.
 
+
 ### Setting `GODOT4_BIN` to a Relative Path
 
-If you have multiple Godot workspaces on a machine, you may want a workspace-independent method of setting the `GODOT4_BIN` environment variable so the matching Godot editor binary for that workspace is always used in the build process, without having to set `GODOT4_BIN` differently for each location.
+If you have multiple Godot workspaces on a machine, you may want a workspace-independent method of setting the `GODOT4_BIN` environment variable
+so the matching Godot editor binary for that workspace is always used in the build process, without having to set `GODOT4_BIN` differently for each
+location.
 
 You can do this by configuring Cargo to set `GODOT4_BIN` to a relative path for you, in `.cargo/config.toml`.
 
-In the root of your Rust project, create `.cargo/config.toml` with the example content shown below, modifying the editor path as needed to find your binary. The path you set will be resolved relative to the location of the `.cargo` directory.
+In the root of your Rust project, create `.cargo/config.toml` with the example content shown below, modifying the editor path as needed to find
+your binary. The path you set will be resolved relative to the location of the `.cargo` directory.
 
 ```toml
 [env]
@@ -63,7 +67,8 @@ GODOT4_BIN = { value = "../godot/bin/godot.linuxbsd.editor.x86_64", relative = t
 
 Test your change by running `cargo build`.
 
-See [The Cargo Book](https://doc.rust-lang.org/cargo/reference/config.html) for more information on customizing your build environment with `config.toml`.
+See [The Cargo Book](https://doc.rust-lang.org/cargo/reference/config.html) for more information on customizing your build environment with
+`config.toml`.
 
 
 [Compatibility and stability]: compatibility.md

--- a/src/toolchain/godot-version.md
+++ b/src/toolchain/godot-version.md
@@ -46,6 +46,25 @@ Note that we do not give any support or compatibility guarantees for custom-buil
 Note that this requires the `bindgen`, as such you may need to install the LLVM toolchain.
 Consult the [setup page][setup-llvm] for more information.
 
+### Setting `GODOT4_BIN` to a Relative Path
+
+If you have multiple Godot workspaces on a machine, you may want a workspace-independent method of setting the `GODOT4_BIN` environment variable so the matching Godot editor binary for that workspace is always used in the build process, without having to set `GODOT4_BIN` differently for each location.
+
+You can do this by configuring Cargo to set `GODOT4_BIN` to a relative path for you, in `.cargo/config.toml`.
+
+In the root of your Rust project, create `.cargo/config.toml` with the example content shown below, modifying the editor path as needed to find your binary. The path you set will be resolved relative to the location of the `.cargo` directory.
+
+```toml
+[env]
+GODOT4_BIN = { value = "../godot/bin/godot.linuxbsd.editor.x86_64", relative = true, force = true }
+```
+
+(If you want to override `config.toml` by setting `GODOT4_BIN` in your environment, remove `force = true`.)
+
+Test your change by running `cargo build`.
+
+See [The Cargo Book](https://doc.rust-lang.org/cargo/reference/config.html) for more information on customizing your build environment with `config.toml`.
+
 
 [Compatibility and stability]: compatibility.md
 [compat-guarantees]: compatibility.md#current-guarantees


### PR DESCRIPTION
Useful when working with multiple workspaces on one machine. Related issue: https://github.com/godot-rust/gdext/issues/540