### PR TITLE
fix borrow of angular_speed

### DIFF
--- a/src/intro/hello-world.md
+++ b/src/intro/hello-world.md
@@ -343,7 +343,8 @@ impl ISprite2D for Player {
         // In GDScript, this would be: 
         // rotation += angular_speed * delta
         
-        self.base_mut().rotate((self.angular_speed * delta) as f32);
+        let radians = (self.angular_speed * delta) as f32;
+        self.base_mut().rotate(radians);
         // The 'rotate' method requires a f32, 
         // therefore we convert 'self.angular_speed * delta' which is a f64 to a f32
     }
@@ -389,7 +390,8 @@ impl ISprite2D for Player {
         // var velocity = Vector2.UP.rotated(rotation) * speed
         // position += velocity * delta
         
-        self.base_mut().rotate((self.angular_speed * delta) as f32);
+        let radians = (self.angular_speed * delta) as f32;
+        self.base_mut().rotate(radians);
 
         let rotation = self.base().get_rotation();
         let velocity = Vector2::UP.rotated(rotation) * self.speed as f32;


### PR DESCRIPTION
While working through the book, I got the following error:

```
error[E0503]: cannot use `self.angular_speed` because it was mutably borrowed
  --> src/player.rs:28:33
   |
28 |         self.base_mut().rotate((self.angular_speed * delta) as f32);
   |         ---------------         ^^^^^^^^^^^^^^^^^^                 - ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `BaseMut<'_, Player>`
   |         |                       |
   |         |                       use of borrowed `*self`
   |         `*self` is borrowed here
   |         a temporary with access to the borrow is created here ...
```

This commit changes the example to set a variable with the `rotate` argument first, I named that argument `radians` to match the parameter name.
