### PR TITLE
Quick fixes to links and title capitalization

### DIFF
--- a/src/recipes/custom-resources.md
+++ b/src/recipes/custom-resources.md
@@ -5,7 +5,7 @@
   ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 -->
 
-# Custom Resources
+# Custom resources
 
 Custom `Resource`s are exposed to the end user to use within their development. `Resource`s can store data that is easily edited from within
 the editor GUI. For example, you can create a custom `AudioStream` type that handles a new and interesting audio file type.

--- a/src/recipes/editor-plugin.md
+++ b/src/recipes/editor-plugin.md
@@ -45,9 +45,9 @@ which allows adding different GUI elements to the editor directly. This can be h
 advanced GUI you want to implement.
 
 ```admonish hint title="Gameplay-only code"
-Use an [ `is_editor_hint` guard][editor-guard] if you don't want some code executing during runtime of the game.
+Use an [ `is_editor_hint` guard][api-engine-iseditorhint] if you don't want some code executing during runtime of the game.
 
-[Read more information on guard clauses in computer science.][guard-csci]
+[Read more information on guard clauses in computer science.][wiki-guard-csci]
 
 [api-engine-iseditorhint]: https://godot-rust.github.io/docs/gdext/master/godot/engine/struct.Engine.html#method.is_editor_hint
 [wiki-guard-csci]: https://en.wikipedia.org/wiki/Guard_(computer_science)

--- a/src/recipes/editor-plugin.md
+++ b/src/recipes/editor-plugin.md
@@ -45,7 +45,7 @@ which allows adding different GUI elements to the editor directly. This can be h
 advanced GUI you want to implement.
 
 ```admonish hint title="Gameplay-only code"
-Use an [ `is_editor_hint` guard][api-engine-iseditorhint] if you don't want some code executing during runtime of the game.
+Use an [`is_editor_hint` guard][api-engine-iseditorhint] if you don't want some code executing during runtime of the game.
 
 [Read more information on guard clauses in computer science.][wiki-guard-csci]
 


### PR DESCRIPTION
Made some quick fixes to the links mentioned in the discord and I quickly perused the titles and found a capitalization error. 