### PR TITLE
add required attribute to editor-plugin tutorial

### DIFF
--- a/src/recipes/editor-plugin.md
+++ b/src/recipes/editor-plugin.md
@@ -27,6 +27,7 @@ struct MyEditorPlugin {
     base: Base<EditorPlugin>,
 }
 
+#[godot_api]
 impl IEditorPlugin for MyEditorPlugin {
     fn enter_tree(&mut self) {
         // Perform typical plugin operations here.


### PR DESCRIPTION
See title. Pasting the code directly from the tutorial will cause an error.

If we'd rather keep it to a self-contained `impl` block, I could change it to something like 
```rust 
#[godot_api]
impl MyEditorPlugin {}
```