### PR TITLE
Fixed potential typo in index.md

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -47,7 +47,7 @@ To avoid confusion, here is an explanation of names and technologies you may enc
 - [**GDNative**][ref-godot-gdnative]: C API provided by Godot 3.
 - [**gdext**][github-gdext] (lowercase): the Rust binding for GDExtension (Godot 4) -- what this book focuses on.
 - [**gdnative**][github-gdnative] (lowercase): the Rust binding for GDNative (Godot 3).
-- **Extension**: An extension is a C library developed using gdext. It can be loaded by Godot 4.
+- **Extension**: An extension is a C library developed using GDExtension. It can be loaded by Godot 4.
 
 
 ### GDExtension API: what's new

--- a/src/index.md
+++ b/src/index.md
@@ -1,4 +1,4 @@
-**<!--
+<!--
   ~ Copyright (c) godot-rust; Bromeon and contributors.
   ~ This Source Code Form is subject to the terms of the Mozilla Public
   ~ License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/index.md
+++ b/src/index.md
@@ -1,4 +1,4 @@
-<!--
+**<!--
   ~ Copyright (c) godot-rust; Bromeon and contributors.
   ~ This Source Code Form is subject to the terms of the Mozilla Public
   ~ License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -47,7 +47,8 @@ To avoid confusion, here is an explanation of names and technologies you may enc
 - [**GDNative**][ref-godot-gdnative]: C API provided by Godot 3.
 - [**gdext**][github-gdext] (lowercase): the Rust binding for GDExtension (Godot 4) -- what this book focuses on.
 - [**gdnative**][github-gdnative] (lowercase): the Rust binding for GDNative (Godot 3).
-- **Extension**: An extension is a dynamic C library, developed by any language binding (Rust, C++, Swift, ...). It uses the GDExtension API and can be loaded by Godot 4.
+- **Extension**: An extension is a dynamic C library, developed by any language binding (Rust, C++, Swift, ...). It uses the GDExtension API and can
+  be loaded by Godot 4.
 
 
 ### GDExtension API: what's new
@@ -95,3 +96,4 @@ That said, there are some notable differences:
 [github-gdext]: https://github.com/godot-rust/gdext
 [github-gdnative]: https://github.com/godot-rust/gdnative
 [github-contributors]: https://github.com/godot-rust/gdext/graphs/contributors
+**

--- a/src/index.md
+++ b/src/index.md
@@ -47,7 +47,7 @@ To avoid confusion, here is an explanation of names and technologies you may enc
 - [**GDNative**][ref-godot-gdnative]: C API provided by Godot 3.
 - [**gdext**][github-gdext] (lowercase): the Rust binding for GDExtension (Godot 4) -- what this book focuses on.
 - [**gdnative**][github-gdnative] (lowercase): the Rust binding for GDNative (Godot 3).
-- **Extension**: An extension is a C library developed using GDExtension. It can be loaded by Godot 4.
+- **Extension**: An extension is a library written in C, or another language binding, using GDExtension. It can be loaded by Godot 4.
 
 
 ### GDExtension API: what's new

--- a/src/index.md
+++ b/src/index.md
@@ -47,7 +47,7 @@ To avoid confusion, here is an explanation of names and technologies you may enc
 - [**GDNative**][ref-godot-gdnative]: C API provided by Godot 3.
 - [**gdext**][github-gdext] (lowercase): the Rust binding for GDExtension (Godot 4) -- what this book focuses on.
 - [**gdnative**][github-gdnative] (lowercase): the Rust binding for GDNative (Godot 3).
-- **Extension**: An extension is a library written in C, or another language binding, using GDExtension. It can be loaded by Godot 4.
+- **Extension**: An extension is a dynamic C library, developed by any language binding (Rust, C++, Swift, ...). It uses the GDExtension API and can be loaded by Godot 4.
 
 
 ### GDExtension API: what's new


### PR DESCRIPTION
From reading this section, I believe that you meant to say that an Extension is developed with GDExtension (the C API provided by Godot), when you actually say "gdext" (the Rust binding).

My apologies if this was the intended wording.  Please discard this pull request if so.  I am new to both Godot and Rust but I am interested to learn, and this wording confused me at first.