### PR TITLE
Fix links in `recipes/custom-resources.rs`

### DIFF
--- a/src/recipes/custom-resources.md
+++ b/src/recipes/custom-resources.md
@@ -31,5 +31,5 @@ The above resource does not export any variables. While not all resources requir
 The systems for registering functions, properties, and more are described in detail in the
 [Registering Rust symbols][register] section.
 
-[hello]: /intro/hello-world.md
-[register]: /register/index.html
+[hello]: ../intro/hello-world.md
+[register]: ../register/index.html


### PR DESCRIPTION
Fixes two links that previously redirected to the root directory of https://godot-rust.github.io/ instead of the `book` subdirectory.

(i.e. https://godot-rust.github.io/intro/hello-world.html -> https://godot-rust.github.io/book/intro/hello-world.html)

Hard to diagnose because it redirects just fine when viewing the book locally 😅