### PR TITLE
Add missing rustflags for exporting to web

### DIFF
--- a/src/toolchain/export-web.md
+++ b/src/toolchain/export-web.md
@@ -74,7 +74,13 @@ rustflags = [
     "-C", "link-args=-sSIDE_MODULE=2",
     "-C", "link-args=-pthread", # was -sUSE_PTHREADS=1 in earlier emscripten versions
     "-C", "target-feature=+atomics,+bulk-memory,+mutable-globals",
-    "-Zlink-native-libraries=no"
+    "-Zlink-native-libraries=no",
+    "-Clink-arg=-fwasm-exceptions",
+    "-Clink-args=-sDISABLE_EXCEPTION_CATCHING=1",
+    "-Clink-args=-sEXPORT_ALL=1",
+    "-Clink-args=-sSUPPORT_LONGJMP=wasm",
+    "-Cllvm-args=-enable-emscripten-cxx-exceptions=0",
+    "-Cllvm-args=-wasm-enable-sjlj",
 ]
 ```
 

--- a/src/toolchain/export-web.md
+++ b/src/toolchain/export-web.md
@@ -75,12 +75,7 @@ rustflags = [
     "-C", "link-args=-pthread", # was -sUSE_PTHREADS=1 in earlier emscripten versions
     "-C", "target-feature=+atomics,+bulk-memory,+mutable-globals",
     "-Zlink-native-libraries=no",
-    "-Clink-arg=-fwasm-exceptions",
-    "-Clink-args=-sDISABLE_EXCEPTION_CATCHING=1",
-    "-Clink-args=-sEXPORT_ALL=1",
-    "-Clink-args=-sSUPPORT_LONGJMP=wasm",
     "-Cllvm-args=-enable-emscripten-cxx-exceptions=0",
-    "-Cllvm-args=-wasm-enable-sjlj",
 ]
 ```
 


### PR DESCRIPTION
According to [a message in the Discord server](https://discord.com/channels/723850269347283004/1311869218572210207/1312024661860683847), you probably need some [more flags](https://discord.com/channels/723850269347283004/1274080437198651546/1275336695264575542) in order to properly export to the web. In my experience, these flags make it work! I have not tested to verify whether this is the exact set needed or a superset.