### PR TITLE
Update to examples that use Strings for passing arguments.

### DIFF
--- a/src/godot-api/builtins.md
+++ b/src/godot-api/builtins.md
@@ -29,7 +29,7 @@ Here is an exhaustive list of all built-in types, by category. We use the GDScri
 - Variant (able to hold anything): `Variant`
 - String types: `String`, `StringName`, `NodePath`
 - Ref-counted containers: `Array` (`Array[T]`), `Dictionary`
-- Packed arrays: `Packed*Array` for following element types:  
+- Packed arrays: `Packed*Array` for following element types:
   `Byte`, `Int32`, `Int64`, `Float32`, `Float64`, `Vector2`, `Vector3`, `Vector4`[^packed-vec4], `Color`, `String`
 - Functional: `Callable`, `Signal`
 
@@ -84,8 +84,18 @@ Godot provides three string types: `String` ([`GString`][api-gstring] in Rust), 
 `GString` is used as a general-purpose string, while `StringName` is often used for identifiers like class or action names.
 The idea is that `StringName` is cheap to construct and compare.[^string-name-Rust]
 
-These types all support `From` traits to convert to/from Rust `String`, and from `&str`. You can thus use `"some_string".into()` expressions.
-If you need more explicit typing, use `StringName::from("some_string")`.
+When working with Godot APIs, you can pass references to the parameter type (e.g. &GString), as well as Rust strings `&str`, and `&String`.
+To convert different string types in argument contexts (e.g. `StringName` -> `GString`), you can call `arg()`.
+
+```rust
+// Label::set_text() takes impl AsArg<GString>.
+label.set_text("my text");
+label.set_text(&string);           // Rust String
+label.set_text(&gstring);          // GString
+label.set_text(string_name.arg()); // StringName
+```
+
+Outside argument contexts, the `From` trait is implemented for string conversions: `GString::From("my string")`, or `"my_string".into()`.
 
 `StringName` in particular provides a direct conversion from C-string literals such as `c"string"`, [introduced in Rust 1.77][rust-c-strings].
 This can be used for _static_ C-strings, i.e. ones that remain allocated for the entire program lifetime. Don't use them for short-lived ones.
@@ -205,7 +215,7 @@ allocate its own memory and copy the data.
 these types more specifically, so it's possible to encounter `i8`, `u64`, `f32` etc.
 
 [^str-types]: String types `GString`, `StringName`, and `NodePath` can be passed into Godot APIs as string literals, hence the `"string"` syntax
-in this example. To assign to your own value, e.g. of type `GString`, you can use `GString::from("string")` or `"string".into()`.
+in this example. To assign to your own value, e.g. of type `GString`, you can use `GString::from("string")` or `"string"`.
 
 [^string-name-Rust]: When constructing `StringName` from `&str` or `String`, the conversion is rather expensive, since UTF-8 is re-encoded as
 UTF-32. As Rust recently introduced C-string literals (`c"hello"`), we can now directly construct from them in case of ASCII. This is more

--- a/src/godot-api/builtins.md
+++ b/src/godot-api/builtins.md
@@ -84,7 +84,7 @@ Godot provides three string types: `String` ([`GString`][api-gstring] in Rust), 
 `GString` is used as a general-purpose string, while `StringName` is often used for identifiers like class or action names.
 The idea is that `StringName` is cheap to construct and compare.[^string-name-Rust]
 
-When working with Godot APIs, you can pass references to the parameter type (e.g. &GString), as well as Rust strings `&str`, and `&String`.
+When working with Godot APIs, you can pass references to the parameter type (e.g. `&GString`), as well as Rust strings `&str`, and `&String`.
 To convert different string types in argument contexts (e.g. `StringName` -> `GString`), you can call `arg()`.
 
 ```rust

--- a/src/godot-api/builtins.md
+++ b/src/godot-api/builtins.md
@@ -29,7 +29,7 @@ Here is an exhaustive list of all built-in types, by category. We use the GDScri
 - Variant (able to hold anything): `Variant`
 - String types: `String`, `StringName`, `NodePath`
 - Ref-counted containers: `Array` (`Array[T]`), `Dictionary`
-- Packed arrays: `Packed*Array` for following element types:
+- Packed arrays: `Packed*Array` for following element types:  
   `Byte`, `Int32`, `Int64`, `Float32`, `Float64`, `Vector2`, `Vector3`, `Vector4`[^packed-vec4], `Color`, `String`
 - Functional: `Callable`, `Signal`
 

--- a/src/migrate/index.md
+++ b/src/migrate/index.md
@@ -1,0 +1,1 @@
+# Migration guides

--- a/src/migrate/index.md
+++ b/src/migrate/index.md
@@ -1,1 +1,8 @@
+<!--
+  ~ Copyright (c) godot-rust; Bromeon and contributors.
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+-->
+
 # Migration guides

--- a/src/recipes/editor-plugin/inspector-plugins.md
+++ b/src/recipes/editor-plugin/inspector-plugins.md
@@ -75,11 +75,11 @@ impl IEditorProperty for RandomIntEditor {
     fn enter_tree(&mut self) {
         // Create button element.
         let mut button = Button::new_alloc();
-        
+
         // Add handler for this button, handle_press will be define in another impl.
         button.connect("pressed", self.base().callable("handle_press"));
         button.set_text("Randomize");
-        
+
         // Save pointer to the button into struct.
         self.button = Some(button.clone());
         self.base_mut().add_child(button.upcast());
@@ -118,7 +118,7 @@ impl RandomIntEditor {
 
         if let Some(mut button) = self.button.clone() {
             let text = format!("Randomize: {num}");
-            button.set_text(text.into());
+            button.set_text(&text);
         } else {
             // Print error of something went wrong
             godot_error!("Button wasn't found in handle_press");
@@ -226,4 +226,3 @@ ERROR: Cannot get class 'RandomInspectorPlugin'.
 ERROR: Cannot get class 'RandomInspectorPlugin'.
    at: (core/object/class_db.cpp:392)
 ```
-

--- a/src/recipes/engine-singleton.md
+++ b/src/recipes/engine-singleton.md
@@ -71,32 +71,34 @@ struct MyExtension;
 unsafe impl ExtensionLibrary for MyExtension {
     fn on_level_init(level: InitLevel) {
         if level == InitLevel::Scene {
-            // The StringName identifies your singleton and can be
+            // The `&str` identifies your singleton and can be
             // used later to access it.
             Engine::singleton().register_singleton(
-                StringName::from("MyEditorSingleton"),
-                MyEditorSingleton::new_alloc().upcast(),
+                "MyEngineSingleton",
+                &MyEngineSingleton::new_alloc(),
             );
         }
     }
 
     fn on_level_deinit(level: InitLevel) {
         if level == InitLevel::Scene {
-            // Get the `Engine` instance and `StringName` for your singleton.
+            // Let's keep a variable of our Engine singleton instance,
+            // and MyEngineSingleton name.
             let mut engine = Engine::singleton();
-            let singleton_name = StringName::from("MyEditorSingleton");
+            let singleton_name = "MyEngineSingleton";
 
-            // We need to retrieve the pointer to the singleton object,
-            // as it has to be freed manually - unregistering singleton 
-            // doesn't do it automatically.
-            let singleton = engine
-                .get_singleton(singleton_name.clone())
-                .expect("cannot retrieve the singleton");
-
-            // Unregistering singleton and freeing the object itself is needed 
-            // to avoid memory leaks and warnings, especially for hot reloading.
-            engine.unregister_singleton(singleton_name);
-            singleton.free();
+            // Here, we manually retrieve our singleton(s) that we've registered,
+            // so we can unregister them and free them from memory - unregistering
+            // singletons isn't hanled automaticlly by the library.
+            if let Some(my_singleton) = engine.get_singleton(singleton_name) {
+                // Unregistering from Godot, and freeing from memory is required
+                // to avoid memory leaks, warnings, and hot reloading problems.
+                engine.unregister_singleton(singleton_name);
+                my_singleton.free();
+            } else {
+                // You can either recover, or panic from here.
+                godot_error!("Failed to get singleton");
+            }
         }
     }
 }
@@ -104,7 +106,7 @@ unsafe impl ExtensionLibrary for MyExtension {
 
 ```admonish warning title="Singletons inheriting from *RefCounted*"
 Use a manually-managed class as a base (often `Object` will be enough) for custom singletons to avoid prematurely freeing the object.
-If for any reason you need to have an instance of a reference-counted object registered as a singleton, this 
+If for any reason you need to have an instance of a reference-counted object registered as a singleton, this
 [issue thread][refcounted-singleton-issue] presents some possible workarounds.
 ```
 

--- a/src/recipes/engine-singleton.md
+++ b/src/recipes/engine-singleton.md
@@ -89,7 +89,7 @@ unsafe impl ExtensionLibrary for MyExtension {
 
             // Here, we manually retrieve our singleton(s) that we've registered,
             // so we can unregister them and free them from memory - unregistering
-            // singletons isn't hanled automaticlly by the library.
+            // singletons isn't handled automatically by the library.
             if let Some(my_singleton) = engine.get_singleton(singleton_name) {
                 // Unregistering from Godot, and freeing from memory is required
                 // to avoid memory leaks, warnings, and hot reloading problems.


### PR DESCRIPTION
tldr:
- Updated "Registering a singleton" example code.
- Changed all relevant examples of `string.into()` -> `&string`.
- Changed "MyEditorSingleton" -> "MyEngineSingleton" in the "engine-singleton.md" page.