### PR TITLE
Add explanation of `bind`, `bind_mut`, `base`, `base_mut`

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,10 +1,14 @@
 # The godot-rust book
 
 The godot-rust book is a user guide for **gdext**, the Rust bindings to Godot 4.
-The book is still work-in-progress, and contributions are very welcome.
+It covers a large part of the concepts and complements [the API docs][gdext-docs].
+There is also [gdnative-book] for Godot 3.
 
-An online version of the book is available at [godot-rust.github.io/book][book-web].  
-For the gdnative book, check out [gdnative-book].
+> [!Tip]
+> The book is deployed at **[godot-rust.github.io/book][book-web]**.
+
+
+## Local setup
 
 The book is built with [mdBook] and the plugins [mdbook-toc] and [mdbook-admonish]. To install them and build the book locally, you can run:
 
@@ -20,20 +24,23 @@ mdbook serve --open
 ```
 
 
-## Formatting and linting
+### Formatting and linting
 
-We use [markdownlint] to enforce a consistent style across the Markdown files.
+[markdownlint] enforces a consistent style across the Markdown files.
 It is automatically run during CI, but if you have the `npm` toolchain, you can also run it locally:
 
 ```bash
 npm install --global markdownlint-cli2
 ./lint.sh
+
+# To fix certain errors directly:
+./lint.sh fix
 ```
 
 
-## Oxipng
+### Oxipng
 
-We use [oxipng](oxipng) to optimize image file size.
+We use [oxipng] to optimize image file size.
 You can install it with `cargo install oxipng` and then run it as follows:
 
 ```bash
@@ -43,8 +50,8 @@ oxipng --strip safe --alpha -r src
 
 ## Contributing
 
-This repository is for documentation only. Please open pull requests targeting the gdext library itself in the [main repo][gdext].
-Please read the corresponding contributing guidelines in `Contributing.md`.
+This repository is for documentation only. For changes in the library itself, please open pull requests and issues in the [main repo][gdext],
+and read the [contributing guidelines][gdext-contribute].
 
 
 ## License
@@ -53,6 +60,8 @@ Like gdext itself, the gdext book is licensed under [MPL 2.0][mpl].
 
 [book-web]: https://godot-rust.github.io/book
 [gdext]: https://github.com/godot-rust/gdext
+[gdext-docs]: https://godot-rust.github.io/docs/gdext/master/godot
+[gdext-contribute]: https://github.com/godot-rust/gdext/blob/master/Contributing.md
 [gdnative-book]: https://github.com/godot-rust/gdnative-book
 [markdownlint]: https://github.com/DavidAnson/markdownlint
 [mdbook-admonish]: https://github.com/tommilligan/mdbook-admonish
@@ -60,3 +69,4 @@ Like gdext itself, the gdext book is licensed under [MPL 2.0][mpl].
 [mdBook]: https://github.com/rust-lang-nursery/mdBook
 [mpl]: https://www.mozilla.org/en-US/MPL
 [oxipng]: https://github.com/shssoichiro/oxipng
+

--- a/src/godot-api/functions.md
+++ b/src/godot-api/functions.md
@@ -25,10 +25,12 @@ The majority of Godot's functionality is exposed via functions inside classes. P
 
 ## Godot functions
 
-For methods, the first parameter is the receiver, i.e. the object on which the method is called.
+As usual in Rust, functions are split into _methods_ (with a `&self`/`&mut self` receiver) and _associated functions_ (called "static functions"
+in Godot).
 
-The Rust API infers the mutability information from the GDExtension API and uses either `&self` or `&mut self` accordingly. Note that this is
-**informational** only and bears no safety implications, but it can help you make code more expressive.
+To access Godot APIs on a `Gd<T>` pointer, simply call the method on the `Gd` object directly. This works due to `Deref` and `DerefMut` traits,
+which give you an object reference through `Gd`. In a [later][book-function-objects] chapter, we'll also see how to call from and into functions
+defined in Rust.
 
 ```rust
 // Call with &self receiver.
@@ -40,6 +42,10 @@ let mut node = Node::new_alloc();
 let other: Gd<Node> = ...;
 node.add_child(other);
 ```
+
+Whether a method requires a shared reference (`&T`) or an exclusive one (`&mut T`) depends on how the method is declared in the GDExtension API
+(`const` or not). Note that this distinction is **informational** only and bears no safety implications, but it is useful in practice to detect
+accidental modification. Technically, you could always just create another pointer via `Gd::clone()`.
 
 Associated functions (called "static" in GDScript) are invoked on the type itself.
 
@@ -172,8 +178,9 @@ match result {
 [api-acceptdialog-add-button-ex]: https://godot-rust.github.io/docs/gdext/master/godot/classes/struct.AcceptDialog.html#method.add_button_ex
 [api-acceptdialog-add-button]: https://godot-rust.github.io/docs/gdext/master/godot/classes/struct.AcceptDialog.html#method.add_button
 [api-classes]: https://godot-rust.github.io/docs/gdext/master/godot/classes/index.html
-[godot-acceptdialog-add-button]: https://docs.godotengine.org/en/stable/classes/class_acceptdialog.html#class-acceptdialog-method-add-button
-[issue-singleton-no-receiver]: https://github.com/godot-rust/gdext/issues/127
-[godot-object-call]: https://docs.godotengine.org/en/stable/classes/class_object.html#class-object-method-call
 [api-object-call]: https://godot-rust.github.io/docs/gdext/master/godot/classes/struct.Object.html#method.call
 [api-object-trycall]: https://godot-rust.github.io/docs/gdext/master/godot/classes/struct.Object.html#method.try_call
+[book-function-objects]: ../register/functions.html#methods-and-object-access
+[godot-acceptdialog-add-button]: https://docs.godotengine.org/en/stable/classes/class_acceptdialog.html#class-acceptdialog-method-add-button
+[godot-object-call]: https://docs.godotengine.org/en/stable/classes/class_object.html#class-object-method-call
+[issue-singleton-no-receiver]: https://github.com/godot-rust/gdext/issues/127

--- a/src/godot-api/objects.md
+++ b/src/godot-api/objects.md
@@ -188,12 +188,14 @@ generally recommend to fix bugs rather than defensive programming.
 ## Conclusion
 
 Objects are a central concept in the Rust bindings. They represent instances of Godot classes, both engine- and user-defined.
-We have seen how to construct, manage and destroy them. The next chapter will go into calling Godot functions.
+We have seen how to construct, manage and destroy them.
+
+But we still have to _use_ objects, i.e. access functionality their class exposes. The next chapter will go into calling Godot functions.
 
 
-[issue-traits]: https://github.com/godot-rust/gdext/issues/426
-[api-gd-from-init-fn]: https://godot-rust.github.io/docs/gdext/master/godot/obj/struct.Gd.html#method.from_init_fn
 [api-gd-free]: https://godot-rust.github.io/docs/gdext/master/godot/obj/struct.Gd.html#method.free
+[api-gd-from-init-fn]: https://godot-rust.github.io/docs/gdext/master/godot/obj/struct.Gd.html#method.from_init_fn
 [api-gd]: https://godot-rust.github.io/docs/gdext/master/godot/obj/struct.Gd.html
 [api-newalloc]: https://godot-rust.github.io/docs/gdext/master/godot/obj/trait.NewAlloc.html
 [api-newgd]: https://godot-rust.github.io/docs/gdext/master/godot/obj/trait.NewGd.html
+[issue-traits]: https://github.com/godot-rust/gdext/issues/426


### PR DESCRIPTION
Adds a long-overdue basic explanation of how to access `T` inside `Gd<T>` pointers.

Also updates the ReadMe.