### PR TITLE
Replaces deprecated #[init(default = ...)] with #[init(val = ...)]

### DIFF
--- a/src/register/constructors.md
+++ b/src/register/constructors.md
@@ -44,7 +44,7 @@ struct Monster {
 }
 ```
 
-To provide another default value, use `#[init(default = value)]`. This should only be used for simple cases, as it may lead to difficult-to-read
+To provide another default value, use `#[init(val = value)]`. This should only be used for simple cases, as it may lead to difficult-to-read
 code and error messages. This API may also still change.
 
 ```rust
@@ -53,7 +53,7 @@ code and error messages. This API may also still change.
 struct Monster {
     name: String,          // initialized to ""
    
-    #[init(default = 100)]
+    #[init(val = 100)]
     hitpoints: i32,        // initialized to 100
     
     base: Base<Node3D>,    // wired up


### PR DESCRIPTION
The attribute key #[init(val = ...)] replaces #[init(default = ...)]. More information on https://github.com/godot-rust/gdext/pull/844