### PR TITLE
Use `::class_name()` instead of string literal 

### DIFF
--- a/src/recipes/engine-singleton.md
+++ b/src/recipes/engine-singleton.md
@@ -54,6 +54,7 @@ struct MyEditorSingleton {
 impl MyEditorSingleton {
     #[func]
     fn foo(&mut self) {}
+    const NAME:&str = "MyEditorSingleton";
 }
 ```
 
@@ -74,7 +75,7 @@ unsafe impl ExtensionLibrary for MyExtension {
             // The `&str` identifies your singleton and can be
             // used later to access it.
             Engine::singleton().register_singleton(
-                "MyEngineSingleton",
+                MyEngineSingleton::NAME,
                 &MyEngineSingleton::new_alloc(),
             );
         }
@@ -85,15 +86,14 @@ unsafe impl ExtensionLibrary for MyExtension {
             // Let's keep a variable of our Engine singleton instance,
             // and MyEngineSingleton name.
             let mut engine = Engine::singleton();
-            let singleton_name = "MyEngineSingleton";
 
             // Here, we manually retrieve our singleton(s) that we've registered,
             // so we can unregister them and free them from memory - unregistering
             // singletons isn't handled automatically by the library.
-            if let Some(my_singleton) = engine.get_singleton(singleton_name) {
+            if let Some(my_singleton) = engine.get_singleton(MyEngineSingleton::NAME) {
                 // Unregistering from Godot, and freeing from memory is required
                 // to avoid memory leaks, warnings, and hot reloading problems.
-                engine.unregister_singleton(singleton_name);
+                engine.unregister_singleton(MyEngineSingleton::NAME);
                 my_singleton.free();
             } else {
                 // You can either recover, or panic from here.

--- a/src/recipes/engine-singleton.md
+++ b/src/recipes/engine-singleton.md
@@ -54,7 +54,6 @@ struct MyEditorSingleton {
 impl MyEditorSingleton {
     #[func]
     fn foo(&mut self) {}
-    const NAME:&str = "MyEditorSingleton";
 }
 ```
 
@@ -75,7 +74,7 @@ unsafe impl ExtensionLibrary for MyExtension {
             // The `&str` identifies your singleton and can be
             // used later to access it.
             Engine::singleton().register_singleton(
-                MyEngineSingleton::NAME,
+                &MyEngineSingleton::class_name().to_string_name(),
                 &MyEngineSingleton::new_alloc(),
             );
         }
@@ -86,14 +85,15 @@ unsafe impl ExtensionLibrary for MyExtension {
             // Let's keep a variable of our Engine singleton instance,
             // and MyEngineSingleton name.
             let mut engine = Engine::singleton();
+            let singleton_name = &MyEngineSingleton::class_name().to_string_name();
 
             // Here, we manually retrieve our singleton(s) that we've registered,
             // so we can unregister them and free them from memory - unregistering
             // singletons isn't handled automatically by the library.
-            if let Some(my_singleton) = engine.get_singleton(MyEngineSingleton::NAME) {
+            if let Some(my_singleton) = engine.get_singleton(singleton_name) {
                 // Unregistering from Godot, and freeing from memory is required
                 // to avoid memory leaks, warnings, and hot reloading problems.
-                engine.unregister_singleton(MyEngineSingleton::NAME);
+                engine.unregister_singleton(singleton_name);
                 my_singleton.free();
             } else {
                 // You can either recover, or panic from here.


### PR DESCRIPTION
IMHO, for portability, it should be suggested you put your name in your struct, instead of placing the string inside the register/de-register method.