### PR TITLE
Fix: replace outdated info

### DIFF
--- a/src/recipes/custom-resources.md
+++ b/src/recipes/custom-resources.md
@@ -25,7 +25,7 @@ struct ResourceType {
 
 The above resource does not export any variables. While not all resources require exported variables, most do.
 
-If your custom resource has lifecycle methods that need to run in the editor,
+To execute code within the Godot Editor (e.g., overriding `set_property` to run custom logic when editing Inspector properties),
 you should annotate the class with `#[class(tool)]`.
 
 ```rust

--- a/src/recipes/custom-resources.md
+++ b/src/recipes/custom-resources.md
@@ -25,7 +25,7 @@ struct ResourceType {
 
 The above resource does not export any variables. While not all resources require exported variables, most do.
 
-If your custom resource has lifecycle methods (`ready()`, `process()` etc.) that need to run in the editor,
+If your custom resource has lifecycle methods that need to run in the editor,
 you should annotate the class with `#[class(tool)]`.
 
 ```rust
@@ -37,8 +37,30 @@ struct ResourceType {
 
 #[godot_api]
 impl IResource for ResourceType {
-    fn ready(&mut self) { ... }
-    fn process(&mut self, delta: f64) { ... }
+    // String representation of the object.
+    fn to_string(&self) -> GString { ... }
+
+    // Called when the object receives a Godot notification.
+    fn on_notification(&mut self, what: ObjectNotification) { ... }
+
+    // Called whenever get() is called or Godot gets the value of a property.
+    fn get_property(&self, property: StringName) -> Option<Variant> { ... }
+
+    // Called whenever Godot set() is called or Godot sets the value of a property.
+    fn set_property(&mut self, property: StringName, value: Variant) -> bool { ... }
+
+    // Called whenever Godot get_property_list() is called,
+    // the returned vector here is appended to the existing list of properties.
+    fn get_property_list(&mut self) -> Vec<PropertyInfo> { ... }
+
+    // Called whenever Godot retrieves value of property. Allows to customize existing properties.
+    // Every property info goes through this method, except properties added with get_property_list().
+    fn validate_property(&self, property: &mut PropertyInfo) { ... }
+
+    // Called by Godot to tell if a property has a custom revert or not.
+    fn property_get_revert(&self, property: StringName) -> Option<Variant> { ... }
+
+    fn setup_local_to_scene(&mut self) { ... }
 }
 
 ```

--- a/src/recipes/custom-resources.md
+++ b/src/recipes/custom-resources.md
@@ -37,7 +37,8 @@ struct ResourceType {
 
 #[godot_api]
 impl IResource for ResourceType {
-  fn init(base: Base<Resource>) -> Self { ... }
+    fn ready(&mut self) { ... }
+    fn process(&mut self, delta: f64) { ... }
 }
 
 ```

--- a/src/toolchain/compatibility.md
+++ b/src/toolchain/compatibility.md
@@ -81,4 +81,4 @@ Note that many such breaking changes are externally motivated, for example:
 - There are subtleties in the type system or runtime guarantees that can be modeled in a better, safer way (e.g. typed arrays, RIDs).
 - We get feedback from game developers and other users stating that certain workflows are very cumbersome.
 
-Once we get into a more stable feature set, we plan to release versions on crates.io and follow semantic versioning.
+Our [crates.io releases](https://crates.io/crates/godot) adhere to SemVer, but may lag behind the master branch.


### PR DESCRIPTION
fix: double `init`