### PR TITLE
add gdext-cli tool in Project Workflow section. -> index.md

### DIFF
--- a/src/ecosystem/index.md
+++ b/src/ecosystem/index.md
@@ -28,15 +28,15 @@ A list for games is also planned, and will be showcased on a separate page.
 |--------------------------------------------------------------------------------|--------------------------------------------------------------------------|-----------------------------------------------|
 | 🌀 _**Async**_                                                                 |                                                                          |                                               |
 | **[gdext-coroutines]**<br/>Integrate Rust coroutines with Godot's async/await. | [crates.io][gdext-coroutines-crate], [Discord][gdext-coroutines-discord] | ![gdext-coroutines][gdext-coroutines-badge]   |
-| **[godot-tokio]**<br/>Create Tokio runtime for use with godot-rust.            | [crates.io][godot-tokio-crate], [Discord][godot-tokio-discord]           | ![godot-tokio][godot-tokio-badge]             |
+| **[godot-tokio]**<br/>Create Tokio runtime for use with godot-rust.            | [crates.io][godot-tokio-crate], [Discord][godot-tokio-discord]          | ![godot-tokio][godot-tokio-badge]             |
 | ___________________________________________________                            |                                                                          |                                               |
 | 🏗️ _**Project workflow**_                                                     |                                                                          |                                               |
-| **[gd-rehearse]**<br/>Unit tests for godot-rust code.                          | [Discord][gd-rehearse-discord]                                           | ![gd-rehearse][gd-rehearse-badge]             |
-| **[gd-props]**<br/>Resource serialization using `serde`.                       | [Discord][gd-props-discord]                                              | ![gd-props][gd-props-badge]                   |
-| **[gdext-generation]**<br/>Auto-generate the `.gdextension` file.              | [Discord][gdext-generation-discord]                                      | ![gdext-generation][gdext-generation-badge]   |
-| **[godot-rust-cli]**<br/>CLI scripts for Godot with Rust.                      | [Discord][godot-rust-cli-discord]                                        | ![godot-rust-cli][godot-rust-cli-badge]       |
+| **[gd-rehearse]**<br/>Unit tests for godot-rust code.                          | [Discord][gd-rehearse-discord]                                          | ![gd-rehearse][gd-rehearse-badge]             |
+| **[gd-props]**<br/>Resource serialization using `serde`.                       | [Discord][gd-props-discord]                                             | ![gd-props][gd-props-badge]                   |
+| **[gdext-generation]**<br/>Auto-generate the `.gdextension` file.              | [Discord][gdext-generation-discord]                                     | ![gdext-generation][gdext-generation-badge]   |
+| **[godot-rust-cli]**<br/>CLI scripts for Godot with Rust.                      | [Discord][godot-rust-cli-discord]                                       | ![godot-rust-cli][godot-rust-cli-badge]       |
 | **[gdext-cli]**<br/>A CLI tool to generate Godot-Rust projects and scripts.    |                                                                          | ![gdext-cli][gdext-cli-badge]                 |                
-| ___________________________________________________                            |                                                                          |                                               |
+| ___________________________________________________                            |                                      |                                               |
 | 📜 _**Scripting**_                                                             |                                                                          |                                               |
 | **[godot-rust-script]**<br/>Allows Rust scripts to be added to nodes.          |                                                                          | ![godot-rust-script][godot-rust-script-badge] |
 | ___________________________________________________                            |                                                                          |                                               |
@@ -72,7 +72,6 @@ A list for games is also planned, and will be showcased on a separate page.
 
 [gdext-cli]: https://github.com/FrankCasanova/gdext-cli
 [gdext-cli-badge]: https://img.shields.io/github/last-commit/FrankCasanova/gdext-cli
-
 
 [godot-rust-script]: https://github.com/titannano/godot-rust-script
 [godot-rust-script-badge]: https://img.shields.io/github/last-commit/titannano/godot-rust-script

--- a/src/ecosystem/index.md
+++ b/src/ecosystem/index.md
@@ -35,8 +35,8 @@ A list for games is also planned, and will be showcased on a separate page.
 | **[gd-props]**<br/>Resource serialization using `serde`.                       | [Discord][gd-props-discord]                                              | ![gd-props][gd-props-badge]                   |
 | **[gdext-generation]**<br/>Auto-generate the `.gdextension` file.              | [Discord][gdext-generation-discord]                                      | ![gdext-generation][gdext-generation-badge]   |
 | **[godot-rust-cli]**<br/>CLI scripts for Godot with Rust.                      | [Discord][godot-rust-cli-discord]                                        | ![godot-rust-cli][godot-rust-cli-badge]   |
-| **[gdext-cli]**<br/>A CLI tool to generate Godot-Rust projects and scripts.    |                                                                          | ![gdext-cli][gdext-cli-badge]                 |                
-| ___________________________________________________                            |                                      |              
+| **[gdext-cli]**<br/>A CLI tool to generate Godot-Rust projects and scripts.    |                                                                          | ![gdext-cli][gdext-cli-badge]                 |
+| ___________________________________________________                            |                                      |
 | 📜 _**Scripting**_                                                             |                                                                          |                                               |
 | **[godot-rust-script]**<br/>Allows Rust scripts to be added to nodes.          |                                                                          | ![godot-rust-script][godot-rust-script-badge] |
 | ___________________________________________________                            |                                                                          |                                               |

--- a/src/ecosystem/index.md
+++ b/src/ecosystem/index.md
@@ -34,7 +34,8 @@ A list for games is also planned, and will be showcased on a separate page.
 | **[gd-rehearse]**<br/>Unit tests for godot-rust code.                          | [Discord][gd-rehearse-discord]                                           | ![gd-rehearse][gd-rehearse-badge]             |
 | **[gd-props]**<br/>Resource serialization using `serde`.                       | [Discord][gd-props-discord]                                              | ![gd-props][gd-props-badge]                   |
 | **[gdext-generation]**<br/>Auto-generate the `.gdextension` file.              | [Discord][gdext-generation-discord]                                      | ![gdext-generation][gdext-generation-badge]   |
-| **[godot-rust-cli]**<br/>CLI scripts for Godot with Rust.                      | [Discord][godot-rust-cli-discord]                                        | ![godot-rust-cli][godot-rust-cli-badge]   |
+| **[godot-rust-cli]**<br/>CLI scripts for Godot with Rust.                      | [Discord][godot-rust-cli-discord]                                        | ![godot-rust-cli][godot-rust-cli-badge]       |
+| **[gdext-cli]**<br/>A CLI tool to generate Godot-Rust projects and scripts.    |                                                                          | ![gdext-cli][gdext-cli-badge]                 |                
 | ___________________________________________________                            |                                                                          |                                               |
 | 📜 _**Scripting**_                                                             |                                                                          |                                               |
 | **[godot-rust-script]**<br/>Allows Rust scripts to be added to nodes.          |                                                                          | ![godot-rust-script][godot-rust-script-badge] |
@@ -68,6 +69,10 @@ A list for games is also planned, and will be showcased on a separate page.
 [godot-rust-cli]: https://github.com/TheColorRed/godot-rust
 [godot-rust-cli-badge]: https://img.shields.io/github/last-commit/TheColorRed/godot-rust
 [godot-rust-cli-discord]: https://discord.com/channels/723850269347283004/1325220721340977253
+
+[gdext-cli]: https://github.com/FrankCasanova/gdext-cli
+[gdext-cli-badge]: https://img.shields.io/github/last-commit/FrankCasanova/gdext-cli
+
 
 [godot-rust-script]: https://github.com/titannano/godot-rust-script
 [godot-rust-script-badge]: https://img.shields.io/github/last-commit/titannano/godot-rust-script

--- a/src/ecosystem/index.md
+++ b/src/ecosystem/index.md
@@ -28,15 +28,15 @@ A list for games is also planned, and will be showcased on a separate page.
 |--------------------------------------------------------------------------------|--------------------------------------------------------------------------|-----------------------------------------------|
 | 🌀 _**Async**_                                                                 |                                                                          |                                               |
 | **[gdext-coroutines]**<br/>Integrate Rust coroutines with Godot's async/await. | [crates.io][gdext-coroutines-crate], [Discord][gdext-coroutines-discord] | ![gdext-coroutines][gdext-coroutines-badge]   |
-| **[godot-tokio]**<br/>Create Tokio runtime for use with godot-rust.            | [crates.io][godot-tokio-crate], [Discord][godot-tokio-discord]          | ![godot-tokio][godot-tokio-badge]             |
+| **[godot-tokio]**<br/>Create Tokio runtime for use with godot-rust.            | [crates.io][godot-tokio-crate], [Discord][godot-tokio-discord]           | ![godot-tokio][godot-tokio-badge]             |
 | ___________________________________________________                            |                                                                          |                                               |
 | 🏗️ _**Project workflow**_                                                     |                                                                          |                                               |
-| **[gd-rehearse]**<br/>Unit tests for godot-rust code.                          | [Discord][gd-rehearse-discord]                                          | ![gd-rehearse][gd-rehearse-badge]             |
-| **[gd-props]**<br/>Resource serialization using `serde`.                       | [Discord][gd-props-discord]                                             | ![gd-props][gd-props-badge]                   |
-| **[gdext-generation]**<br/>Auto-generate the `.gdextension` file.              | [Discord][gdext-generation-discord]                                     | ![gdext-generation][gdext-generation-badge]   |
-| **[godot-rust-cli]**<br/>CLI scripts for Godot with Rust.                      | [Discord][godot-rust-cli-discord]                                       | ![godot-rust-cli][godot-rust-cli-badge]       |
+| **[gd-rehearse]**<br/>Unit tests for godot-rust code.                          | [Discord][gd-rehearse-discord]                                           | ![gd-rehearse][gd-rehearse-badge]             |
+| **[gd-props]**<br/>Resource serialization using `serde`.                       | [Discord][gd-props-discord]                                              | ![gd-props][gd-props-badge]                   |
+| **[gdext-generation]**<br/>Auto-generate the `.gdextension` file.              | [Discord][gdext-generation-discord]                                      | ![gdext-generation][gdext-generation-badge]   |
+| **[godot-rust-cli]**<br/>CLI scripts for Godot with Rust.                      | [Discord][godot-rust-cli-discord]                                        | ![godot-rust-cli][godot-rust-cli-badge]   |
 | **[gdext-cli]**<br/>A CLI tool to generate Godot-Rust projects and scripts.    |                                                                          | ![gdext-cli][gdext-cli-badge]                 |                
-| ___________________________________________________                            |                                      |                                               |
+| ___________________________________________________                            |                                      |              
 | 📜 _**Scripting**_                                                             |                                                                          |                                               |
 | **[godot-rust-script]**<br/>Allows Rust scripts to be added to nodes.          |                                                                          | ![godot-rust-script][godot-rust-script-badge] |
 | ___________________________________________________                            |                                                                          |                                               |

--- a/src/ecosystem/index.md
+++ b/src/ecosystem/index.md
@@ -35,8 +35,8 @@ A list for games is also planned, and will be showcased on a separate page.
 | **[gd-props]**<br/>Resource serialization using `serde`.                       | [Discord][gd-props-discord]                                              | ![gd-props][gd-props-badge]                   |
 | **[gdext-generation]**<br/>Auto-generate the `.gdextension` file.              | [Discord][gdext-generation-discord]                                      | ![gdext-generation][gdext-generation-badge]   |
 | **[godot-rust-cli]**<br/>CLI scripts for Godot with Rust.                      | [Discord][godot-rust-cli-discord]                                        | ![godot-rust-cli][godot-rust-cli-badge]   |
-| **[gdext-cli]**<br/>A CLI tool to generate Godot-Rust projects and scripts.    |                                                                          | ![gdext-cli][gdext-cli-badge]                 |
-| ___________________________________________________                            |                                      |
+| **[gdext-cli]**<br/>A CLI tool to generate godot-rust projects and scripts.    |                                                                          | ![gdext-cli][gdext-cli-badge]                 |
+| ___________________________________________________|                            |                                      |
 | 📜 _**Scripting**_                                                             |                                                                          |                                               |
 | **[godot-rust-script]**<br/>Allows Rust scripts to be added to nodes.          |                                                                          | ![godot-rust-script][godot-rust-script-badge] |
 | ___________________________________________________                            |                                                                          |                                               |


### PR DESCRIPTION

![togithub-ezgif com-optimize](https://github.com/user-attachments/assets/a2100a50-70cf-4df0-91aa-7a46f1e5d2a5)


Description: The gdext-cli is a CLI tool designed to generate Godot-Rust projects and scripts, making it easier for developers to get started with Godot and Rust integration.

Maintainability guarantees: Me. As an active user of gdext, a tool I'll be using for a long time until I fully master Godot and can start my own projects.
The project will be updated in sync with gdext for my own benefit and, therefore, for the community.
