### PR TITLE
Removing deprecated editor_plugin attribute key

### DIFF
--- a/src/recipes/editor-plugin/index.md
+++ b/src/recipes/editor-plugin/index.md
@@ -22,7 +22,7 @@ you cannot introduce compile-time errors.
 
 ```rust
 #[derive(GodotClass)]
-#[class(tool, init, editor_plugin, base=EditorPlugin)]
+#[class(tool, init, base=EditorPlugin)]
 struct MyEditorPlugin {
     base: Base<EditorPlugin>,
 }

--- a/src/recipes/editor-plugin/inspector-plugins.md
+++ b/src/recipes/editor-plugin/inspector-plugins.md
@@ -187,7 +187,7 @@ on what you want to achieve.
 
 ```rust
 #[derive(GodotClass)]
-#[class(tool, init, editor_plugin, base=EditorPlugin)]
+#[class(tool, init, base=EditorPlugin)]
 struct RustEditorPlugin {
     base: Base<EditorPlugin>,
     random_inspector: Gd<RandomInspectorPlugin>,


### PR DESCRIPTION
In https://github.com/godot-rust/gdext/pull/884, editor_plugin was
deprecated (automatically implied by EditorPlugin), and raises a warning
when provided. Updating the docs to reflect that change.
