### PR TITLE
Adjust target feature instructions for Wasm threading

### DIFF
--- a/src/toolchain/export-web.md
+++ b/src/toolchain/export-web.md
@@ -362,7 +362,7 @@ as otherwise your extension's `.wasm` file may be overwritten, leading to confus
     likely not help at all.
 
     Some common panic causes include:
-      - Attempting to call certain threaded code in a `nothreads` build, such as `std::thread::spawn(...)` or `thread_local!`;
+      - Attempting to call certain multi-threaded code in a `nothreads` build, such as `std::thread::spawn(...)`;
       - Using panicking variants of methods, such as `Array::at` instead of `Array::get`;
       - Calling `.unwrap()` on `Option::None` or `Result::Err`.
 


### PR DESCRIPTION
Based on findings from https://github.com/godot-rust/gdext/pull/1105 and https://github.com/godot-rust/gdext/pull/1107, I propose:

1. Suggesting removing `-Ctarget-features=+atomics` when compiling a nothreads build, to ensure `std` is compiled without multi-threading (using polyfills for threading APIs).
2. Suggesting not adding the `+mutable-globals` target feature anymore in any wasm builds, as it appears to be stable and enabled by default now, per https://doc.rust-lang.org/1.85.1/rustc/platform-support/wasm32-unknown-unknown.html#enabled-webassembly-features
3. **Tentatively** suggesting removing the `+bulk-memory` target feature as well. In principle, some error messages from emscripten suggest to me that `+atomics` is sufficient here, as removing this flag made my rather simple test project  (with async signals for fancier testing) work all the same. However, let's keep an eye on this in case someone has a problem with this.
4. Updating some minor things