### PR TITLE
Update ubuntu runner for license-guard to ubuntu-22.04

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -86,7 +86,7 @@ jobs:
 
 
   license-guard:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/11101