### PR TITLE
Remove outdated info in signals chapter

### DIFF
--- a/src/register/signals.md
+++ b/src/register/signals.md
@@ -424,7 +424,7 @@ The returned [`ConnectBuilder`][api-connectbuilder] provides several dimensions 
 - Connection flags: `DEFERRED`, `ONESHOT`, `PERSIST`
 - Single-threaded (default) or thread-crossing ("sync")
 
-To finish it, `done()` is invoked. Some example setups:
+Some example setups:
 
 ```rust
 // Connect -> Self::log_event(&mut self, event: String)


### PR DESCRIPTION
[`ConnectBuilder::done`: removed](https://github.com/godot-rust/gdext/pull/1152/commits/74a11b0ea2a60109532e77c420b6ba7fc13dfa49)