### PR TITLE
Stringify function guidance

### DIFF
--- a/src/intro/hello-world.md
+++ b/src/intro/hello-world.md
@@ -449,7 +449,7 @@ impl Player {
     #[func]
     fn increase_speed(&mut self, amount: f64) {
         self.speed += amount;
-        self.base_mut().emit_signal("speed_increased", &[]);
+        self.base_mut().emit_signal(stringify!(speed_increased), &[]);
     }
 
     #[signal]

--- a/src/intro/hello-world.md
+++ b/src/intro/hello-world.md
@@ -449,7 +449,7 @@ impl Player {
     #[func]
     fn increase_speed(&mut self, amount: f64) {
         self.speed += amount;
-        self.base_mut().emit_signal(stringify!(speed_increased), &[]);
+        self.signals().speed_increased().emit();
     }
 
     #[signal]


### PR DESCRIPTION
Replaced a string literal with the `stringify!` macro, which is safer for refactoring/renames. 