### PR TITLE
docs(signals): add disclaimer about version requirement

### DIFF
--- a/src/register/signals.md
+++ b/src/register/signals.md
@@ -130,6 +130,8 @@ For typed signals to be available, you need:
   - This must be an inherent impl, the `I*` trait `impl` won't be enough.
   - Leave the impl empty if necessary.
 - A `Base<T>` field.
+- The Latest version of the `godot` dependency.
+  - You may need to specify `godot = { branch = "master", git = "https://github.com/godot-rust/gdext" }` in your `Cargo.toml`.
 
 Signals, typed or not, **cannot** be declared in secondary `impl` blocks (those annotated with `#[godot_api(secondary)]` attribute).
 ```


### PR DESCRIPTION
I was working with `godot = "0.2.3"`.
When copying from the book I was getting an error:

```
no method named `signals` found for mutable reference `&mut Monster` in the current scope method not found in `&mut Monster`
```

On any line attempting to call `self.signals()`. e.g. `let sig = self.signals().damage_taken();`

Fixed error bu switching from `godot = "0.2.3"` to `godot = { branch = "master", git = "https://github.com/godot-rust/gdext" }`