### PR TITLE
docs(debugger): Updated the debugger configuration for Visual Studio Code

### DIFF
--- a/src/toolchain/debugging.md
+++ b/src/toolchain/debugging.md
@@ -17,32 +17,43 @@ you will only have symbols for stack frames in Rust code.
 
 ## Launching with VS Code
 
-Here is an example launch configuration for Visual Studio Code. Launch configurations should be added to  `./.vscode/launch.json`, relative
-to your project's root. This example assumes you have the [CodeLLDB] extension installed, which is common for Rust development.
+Here is an example debugger setup for Visual Studio Code. Launch configurations and tasks should be placed in`./.vscode/launch.json` and
+`./.vscode/tasks.json` respectively, relative to your project's root.
+
+This example assumes you have the [CodeLLDB] extension installed, which is common for Rust development.
 
 ```json
+// ./.vscode/launch.json
 {
     "configurations": [
         {
             "name": "Debug Project (Godot 4)",
             "type": "lldb", // type provided by CodeLLDB extension
             "request": "launch",
-            "preLaunchTask": "rust: cargo build",
-            "cwd": "${workspaceFolder}",
+            "cwd": "${workspaceFolder}/godot",
+            "preLaunchTask": "build-rust",
             "args": [
-                "-e", // run editor (remove this to launch the scene directly)
-                "-w", // windowed mode
+                "-w" // windowed mode
             ],
-            "linux": {
-                "program": "/usr/local/bin/godot4",
-            },
-            "windows": {
-                "program": "C:\\Program Files\\Godot\\Godot_v4.1.X.exe",
-            },
-            "osx": {
-                // NOTE: on macOS the Godot.app needs to be manually re-signed 
-                // to enable debugging (see below)
-                "program": "/Applications/Godot.app/Contents/MacOS/Godot",
+            "program": "PATH/TO/GODOT"
+        }
+    ]
+}
+```
+
+```json
+// ./.vscode/tasks.json
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build-rust",
+            "command": "cargo",
+            "args": [
+                "build"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/rust"
             }
         }
     ]

--- a/src/toolchain/debugging.md
+++ b/src/toolchain/debugging.md
@@ -17,32 +17,41 @@ you will only have symbols for stack frames in Rust code.
 
 ## Launching with VS Code
 
-Here is an example launch configuration for Visual Studio Code. Launch configurations should be added to  `./.vscode/launch.json`, relative
+Here is an example debugger setup for Visual Studio Code. Launch configurations and tasks should be placed in `./.vscode/launch.json` and  `./.vscode/tasks.json` respectively, relative
 to your project's root. This example assumes you have the [CodeLLDB] extension installed, which is common for Rust development.
 
-```json
+```jsonc
+// ./.vscode/launch.json
 {
     "configurations": [
         {
             "name": "Debug Project (Godot 4)",
-            "type": "lldb", // type provided by CodeLLDB extension
+            "type": "lldb",
             "request": "launch",
-            "preLaunchTask": "rust: cargo build",
-            "cwd": "${workspaceFolder}",
+            "cwd": "${workspaceFolder}/godot",
+            "preLaunchTask": "build-rust",
             "args": [
-                "-e", // run editor (remove this to launch the scene directly)
-                "-w", // windowed mode
+                "-w"
             ],
-            "linux": {
-                "program": "/usr/local/bin/godot4",
-            },
-            "windows": {
-                "program": "C:\\Program Files\\Godot\\Godot_v4.1.X.exe",
-            },
-            "osx": {
-                // NOTE: on macOS the Godot.app needs to be manually re-signed 
-                // to enable debugging (see below)
-                "program": "/Applications/Godot.app/Contents/MacOS/Godot",
+            "program": "PATH/TO/GODOT"
+        }
+    ]
+}
+```
+
+```jsonc
+// ./.vscode/tasks.json
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build-rust",
+            "command": "cargo",
+            "args": [
+                "build"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/rust"
             }
         }
     ]

--- a/src/toolchain/debugging.md
+++ b/src/toolchain/debugging.md
@@ -17,7 +17,7 @@ you will only have symbols for stack frames in Rust code.
 
 ## Launching with VS Code
 
-Here is an example debugger setup for Visual Studio Code. Launch configurations and tasks should be placed in`./.vscode/launch.json` and 
+Here is an example debugger setup for Visual Studio Code. Launch configurations and tasks should be placed in`./.vscode/launch.json` and
 `./.vscode/tasks.json` respectively, relative to your project's root.
 
 This example assumes you have the [CodeLLDB] extension installed, which is common for Rust development.

--- a/src/toolchain/debugging.md
+++ b/src/toolchain/debugging.md
@@ -22,6 +22,8 @@ Here is an example debugger setup for Visual Studio Code. Launch configurations 
 
 This example assumes you have the [CodeLLDB] extension installed, which is common for Rust development.
 
+For commands like `-w` (windowed mode) or `-e` (editor), refer to Godot's [command line tutorial][godot-command-line].
+
 ```json
 // ./.vscode/launch.json
 {
@@ -34,6 +36,7 @@ This example assumes you have the [CodeLLDB] extension installed, which is commo
             "preLaunchTask": "build-rust",
             "args": [
                 "-w" // windowed mode
+                // "-e": editor does not keep breakpoints; thus not listed here.
             ],
             "program": "PATH/TO/GODOT"
         }
@@ -108,3 +111,4 @@ in Terminal to complete the re-signing process. It is recommended to check this 
 re-sign their local installation if you have a team. This process should only be necessary once per Godot installation though.
 
 [CodeLLDB]: https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb
+[godot-command-line]: https://docs.godotengine.org/en/latest/tutorials/editor/command_line_tutorial.html#command-line-reference

--- a/src/toolchain/debugging.md
+++ b/src/toolchain/debugging.md
@@ -17,8 +17,10 @@ you will only have symbols for stack frames in Rust code.
 
 ## Launching with VS Code
 
-Here is an example debugger setup for Visual Studio Code. Launch configurations and tasks should be placed in `./.vscode/launch.json` and  `./.vscode/tasks.json` respectively, relative
-to your project's root. This example assumes you have the [CodeLLDB] extension installed, which is common for Rust development.
+Here is an example debugger setup for Visual Studio Code. Launch configurations and tasks should be placed in`./.vscode/launch.json` and 
+`./.vscode/tasks.json` respectively, relative to your project's root.
+
+This example assumes you have the [CodeLLDB] extension installed, which is common for Rust development.
 
 ```jsonc
 // ./.vscode/launch.json

--- a/src/toolchain/debugging.md
+++ b/src/toolchain/debugging.md
@@ -22,18 +22,18 @@ Here is an example debugger setup for Visual Studio Code. Launch configurations 
 
 This example assumes you have the [CodeLLDB] extension installed, which is common for Rust development.
 
-```jsonc
+```json
 // ./.vscode/launch.json
 {
     "configurations": [
         {
             "name": "Debug Project (Godot 4)",
-            "type": "lldb",
+            "type": "lldb", // type provided by CodeLLDB extension
             "request": "launch",
             "cwd": "${workspaceFolder}/godot",
             "preLaunchTask": "build-rust",
             "args": [
-                "-w"
+                "-w" // windowed mode
             ],
             "program": "PATH/TO/GODOT"
         }
@@ -41,7 +41,7 @@ This example assumes you have the [CodeLLDB] extension installed, which is commo
 }
 ```
 
-```jsonc
+```json
 // ./.vscode/tasks.json
 {
     "version": "2.0.0",


### PR DESCRIPTION
Updated the debugging documentation for VS Code as the prior configurations was outdated

These where the previous issues of the example configuration
- Warning: Missing property "program"
- The attempt to launch cross-platform seems to be not supported. You can't run platform per OS, only pass in arguments per OS to program via args https://code.visualstudio.com/docs/debugtest/debugging-configuration#_platformspecific-properties
- Going by the recommended project structure makes "preLaunchTask": "rust: cargo build" not execute correctly. Instead you need a separate tasks.json that builds rust in the correct folder. (See below)
With the given changes these should no longer be a problem.
- Removed the -e argument as starting the debug with godot in editor mode apparently does not keep any breakpoints set in Rust

I would have loved to omit the tasks.json, but sadly its not possible to set a working directory for `cargo build` ([except for running when nightly channel](https://doc.rust-lang.org/cargo/commands/cargo-build.html#common-options))