### PR TITLE
Add troubleshooting note on how to see godot crash logs

### DIFF
--- a/src/intro/hello-world.md
+++ b/src/intro/hello-world.md
@@ -228,6 +228,7 @@ that should solve the most common problems.
 
 - Have you run `cargo build`?
 - In `Cargo.toml`, have you set `crate-type = ["cdylib"]`?
+- Does Godot crash immediately on opening your project? Run `godot4 path/to/project.godot` from the terminal to see the error output.
 - In `my-extension.gdextension`, have you set `entry_symbol = "gdext_rust_init"`?  No other symbol can work.
 - Are the paths set in `my-extension.gdextension` correct?
   - Are you sure?  Double check `/rust/target/debug/` to see if the name of the `.so`/`.dll`/`.dylib` is spelled the way you expect.
@@ -239,7 +240,6 @@ that should solve the most common problems.
 - In case you use `api-custom`, do you have
   - Godot in your `PATH` as `godot4`,
   - or an environment variable called `GODOT4_BIN`, containing the path to the Godot executable?
-- Does Godot crash immediately on opening your project? Run `godot4 path/to/project.godot` from the terminal to see the error output.
 - Is your directory structure like this below?  It's much easier when you ask for help if it is.
 
 ```txt

--- a/src/intro/hello-world.md
+++ b/src/intro/hello-world.md
@@ -239,6 +239,7 @@ that should solve the most common problems.
 - In case you use `api-custom`, do you have
   - Godot in your `PATH` as `godot4`,
   - or an environment variable called `GODOT4_BIN`, containing the path to the Godot executable?
+- Does Godot crash immediately on opening your project? Run `godot4 path/to/project.godot` from the terminal to see the error output.
 - Is your directory structure like this below?  It's much easier when you ask for help if it is.
 
 ```txt


### PR DESCRIPTION
Hey,
I thought it would be a valuable addition to the troubleshooting section in `hello-world.md` to mention that you can start Godot through the terminal to see the error logs produced on launch.

This helped me to figure out why my project crashed. (Because I had a typo in my `.gdextension` file.)

I can imagine this could help other beginners like me :)