### PR TITLE
Update Singleton page to current function naming

### DIFF
--- a/src/recipes/engine-singleton.md
+++ b/src/recipes/engine-singleton.md
@@ -83,7 +83,7 @@ unsafe impl ExtensionLibrary for MyExtension {
     fn on_stage_deinit(stage: InitStage) {
         if stage == InitStage::Scene {
             // Let's keep a variable of our Engine singleton instance,
-            // and MyEngineSingleton name.
+            // and MyEditorSingleton name.
             let mut engine = Engine::singleton();
             let singleton_name = &MyEditorSingleton::class_id().to_string_name();
 

--- a/src/recipes/engine-singleton.md
+++ b/src/recipes/engine-singleton.md
@@ -24,7 +24,7 @@ Custom engine singletons in Godot:
 
 - are `Object` types
 - are always accessible to GDScript and GDExtension languages
-- must be manually registered and unregistered in the `InitLevel::Scene` step
+- must be manually registered and unregistered in the `InitStage::Scene` step
 
 Godot provides _many_ built-in singletons in its API. You can find a full list [here][godot-singleton-list].
 
@@ -60,7 +60,7 @@ impl MyEditorSingleton {
 
 ## Registering a singleton
 
-Registering singletons is done during the `InitLevel::Scene` stage of initialization.
+Registering singletons is done during the `InitStage::Scene` stage of initialization.
 
 To achieve this, we can customize our init/shutdown routines by overriding `ExtensionLibrary` trait methods.
 
@@ -69,23 +69,23 @@ struct MyExtension;
 
 #[gdextension]
 unsafe impl ExtensionLibrary for MyExtension {
-    fn on_level_init(level: InitLevel) {
-        if level == InitLevel::Scene {
+    fn on_stage_init(stage: InitStage) {
+        if stage == InitStage::Scene {
             // The `&str` identifies your singleton and can be
             // used later to access it.
             Engine::singleton().register_singleton(
-                &MyEngineSingleton::class_name().to_string_name(),
+                &MyEngineSingleton::class_id().to_string_name(),
                 &MyEngineSingleton::new_alloc(),
             );
         }
     }
 
-    fn on_level_deinit(level: InitLevel) {
-        if level == InitLevel::Scene {
+    fn on_stage_deinit(stage: InitStage) {
+        if stage == InitStage::Scene {
             // Let's keep a variable of our Engine singleton instance,
             // and MyEngineSingleton name.
             let mut engine = Engine::singleton();
-            let singleton_name = &MyEngineSingleton::class_name().to_string_name();
+            let singleton_name = &MyEngineSingleton::class_id().to_string_name();
 
             // Here, we manually retrieve our singleton(s) that we've registered,
             // so we can unregister them and free them from memory - unregistering

--- a/src/recipes/engine-singleton.md
+++ b/src/recipes/engine-singleton.md
@@ -46,12 +46,12 @@ Defining a singleton is the same as registering a custom class.
 ```rust
 #[derive(GodotClass)]
 #[class(init, base=Object)]
-struct MyEditorSingleton {
+struct MySingleton {
     base: Base<Object>,
 }
 
 #[godot_api]
-impl MyEditorSingleton {
+impl MySingleton {
     #[func]
     fn foo(&mut self) {}
 }
@@ -74,8 +74,8 @@ unsafe impl ExtensionLibrary for MyExtension {
             // The `&str` identifies your singleton and can be
             // used later to access it.
             Engine::singleton().register_singleton(
-                &MyEditorSingleton::class_id().to_string_name(),
-                &MyEditorSingleton::new_alloc(),
+                &MySingleton::class_id().to_string_name(),
+                &MySingleton::new_alloc(),
             );
         }
     }
@@ -83,9 +83,9 @@ unsafe impl ExtensionLibrary for MyExtension {
     fn on_stage_deinit(stage: InitStage) {
         if stage == InitStage::Scene {
             // Let's keep a variable of our Engine singleton instance,
-            // and MyEditorSingleton name.
+            // and MySingleton name.
             let mut engine = Engine::singleton();
-            let singleton_name = &MyEditorSingleton::class_id().to_string_name();
+            let singleton_name = &MySingleton::class_id().to_string_name();
 
             // Here, we manually retrieve our singleton(s) that we've registered,
             // so we can unregister them and free them from memory - unregistering
@@ -121,7 +121,7 @@ Now that your singleton is available (and once you've recompiled and reloaded), 
 extends Node
 
 func _ready() -> void:
-    MyEditorSingleton.foo()
+    MySingleton.foo()
 ```
 
 
@@ -131,7 +131,7 @@ You may also want to access your singleton from Rust as well.
 
 ```rust
 godot::classes::Engine::singleton()
-    .get_singleton(StringName::from("MyEditorSingleton"));
+    .get_singleton(StringName::from("MySingleton"));
 ```
 
 For more information on this method, refer to [the API docs][method-get-singleton].

--- a/src/recipes/engine-singleton.md
+++ b/src/recipes/engine-singleton.md
@@ -74,8 +74,8 @@ unsafe impl ExtensionLibrary for MyExtension {
             // The `&str` identifies your singleton and can be
             // used later to access it.
             Engine::singleton().register_singleton(
-                &MyEngineSingleton::class_id().to_string_name(),
-                &MyEngineSingleton::new_alloc(),
+                &MyEditorSingleton::class_id().to_string_name(),
+                &MyEditorSingleton::new_alloc(),
             );
         }
     }
@@ -85,7 +85,7 @@ unsafe impl ExtensionLibrary for MyExtension {
             // Let's keep a variable of our Engine singleton instance,
             // and MyEngineSingleton name.
             let mut engine = Engine::singleton();
-            let singleton_name = &MyEngineSingleton::class_id().to_string_name();
+            let singleton_name = &MyEditorSingleton::class_id().to_string_name();
 
             // Here, we manually retrieve our singleton(s) that we've registered,
             // so we can unregister them and free them from memory - unregistering


### PR DESCRIPTION
Hi,

This just updates the 'Engine singletons' page to have the current function/enum/class names.
It also matches the registering code with the struct name that's in the previous section.

Thanks,
Paul