### PR TITLE
Adding future and deferred documentation

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -15,6 +15,7 @@
   - [Built-in types](godot-api/builtins.md)
   - [Objects](godot-api/objects.md)
   - [Calling functions](godot-api/functions.md)
+  - [Futures and Deferred Functions](godot-api/async.md)
 - [Registering Rust symbols](register/index.md)
   - [Classes](register/classes.md)
   - [Functions](register/functions.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -15,6 +15,7 @@
   - [Built-in types](godot-api/builtins.md)
   - [Objects](godot-api/objects.md)
   - [Calling functions](godot-api/functions.md)
+  - [Async Programming](godot-api/async.md)
 - [Registering Rust symbols](register/index.md)
   - [Classes](register/classes.md)
   - [Functions](register/functions.md)

--- a/src/godot-api/async.md
+++ b/src/godot-api/async.md
@@ -54,7 +54,7 @@ struct Game {
 #[godot_api]
 impl INode for Game {
     fn ready(&mut self) {
-        // Connect a signal.
+        // Connect signal: $Player.body_entered -> Self::show_messages.
         self.base()
             .get_node_as::<Area2D>("Player")
             .signals()

--- a/src/godot-api/async.md
+++ b/src/godot-api/async.md
@@ -1,0 +1,135 @@
+# Futures and Deferred Functions
+
+Execute logic using a future or a deferred function at the end of the frame.
+
+## Running Deferred logic
+
+Sometimes it is useful to run logic after all of the other logic of the other
+nodes has complete.  While you can ask the
+[godot engine to execute exported Rust functions](https://godot-rust.github.io/gdnative-book/bind/calling-gdscript.html#function-calls)
+, godot-rust also provides a type-safe way to defer executed logic to the next
+frame.
+
+```rust
+use godot::prelude::*;
+
+#[derive(GodotClass)]
+#[class(init, base=Node)]
+struct Game {
+   base: Base<Node>,
+}
+
+#[godot_api]
+impl Game {
+  fn now_and_later(&mut self) {
+      godot_print!("This was run at the beginning of the frame!");
+      self.run_deferred(|_this| {
+          godot_print!("This was run at the end of the frame!")
+      });
+  }
+}
+```
+
+## Futures
+
+Rust's futures are fully supported for integrating asynchronous programming.
+The key point is that you will need you will need a Godot pointer that can be passed
+to `godot::task::spawn`.
+
+```admonish note title="Connecting signals"
+The only way to connect a signal in Rust so that the callback method
+is called with a Godot pointer is to use the signal builder.
+```
+
+```rust
+use godot::prelude::*;
+use godot::classes::{ Area2D };
+
+#[derive(GodotClass)]
+#[class(init, base=Node)]
+struct Game {
+   base: Base<Node>,
+}
+
+#[godot_api]
+impl INode for Game {
+    fn ready(&mut self) {
+        // Connect a signal.
+        self.base()
+            .get_node_as::<Area2D>("Player")
+            .signals()
+            .body_entered()
+            .builder()
+            .connect_other_gd(self, Self::show_messages);
+    }
+}
+
+#[godot_api]
+impl Game {
+    // Async function that implements sleep using Godot timers.
+    async fn sleep(&self, duration: f64) {
+        let timer = self.base().get_tree().create_timer(duration);
+        // Use a future to wait for the timeout signal.
+        timer.signals().timeout().to_future().await;
+    }
+
+    // Show one message immediately, and other after one second.
+    #[func(gd_self)] // Also allow attaching the callback with the Godot editor.
+    fn show_messages(this: Gd<Self>, _area: Gd<Node2D>) {
+        godot::task::spawn(async move {
+            godot_print!("Immediate message!");
+            this.bind().sleep(1.0).await;
+            godot_print!("Message after one second!")
+        });
+    }
+}
+```
+
+```admonish warning title="Getting a Godot pointer in a class method"
+While [it is possible to get a Godot pointer inside of a class method](https://godot-rust.github.io/book/register/functions.html?highlight=bind_mut#calling-rust-methods-binds), `bind()` and
+`bind_mut()` will not be able to return a guarded object as it is ready
+implicity bound for the method call.
+```
+
+```rust
+#[godot_api]
+impl Game {
+    fn crash(&mut self) {
+        // FAIL! While you can have multiple smart pointers, you can't bind
+        // multiple items. This will not release an existing guard.
+        let gd = self.object_to_owned();
+
+        // FAIL! You cannot use drop to free a guard on a borrowed object.
+        std::mem::drop(self); // Doesn't do anything
+
+        godot::task::spawn(async move {
+            // FAIL! `drop` did nothing so this will crash your program!
+            gd.bind_mut();
+        });
+    }
+
+}
+```
+
+```admonish warning title="Joining threads"
+Because the Godot engine is running separate of Rust, you will want
+to be thoughtful on using any native Rust calls for joining async calls
+to avoid a deadlock freezing your program.
+```
+
+```rust
+#[godot_api]
+impl Game {
+    async fn sleep(&self, duration: f64) {
+        let timer = self.base().get_tree().create_timer(duration);
+        timer.signals().timeout().to_future().await;
+    }
+
+    fn freeze_the_program(&mut self) {
+        // FAIL! This will cause a deadlock that will freeze your program
+        // where Rust and Godot are waiting for each other!
+        futures::executor::block_on(self.sleep(1.0));
+    }
+
+}
+```

--- a/src/godot-api/async.md
+++ b/src/godot-api/async.md
@@ -43,7 +43,7 @@ is called with a Godot pointer is to use the signal builder.
 
 ```rust
 use godot::prelude::*;
-use godot::classes::{ Area2D };
+use godot::classes::Area2D;
 
 #[derive(GodotClass)]
 #[class(init, base=Node)]

--- a/src/godot-api/async.md
+++ b/src/godot-api/async.md
@@ -1,0 +1,124 @@
+<!--
+  ~ Copyright (c) godot-rust; Bromeon and contributors.
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+-->
+
+# Async Programming
+
+Execute logic using [futures](https://doc.rust-lang.org/book/ch17-01-futures-and-syntax.html)
+or deferred functions.
+
+
+## Running Deferred Logic
+
+Sometimes it is useful to run logic after all other node processing has completed.
+While the Godot engine can
+[execute exported Rust functions with `call_deferred`](https://godot-rust.github.io/gdnative-book/bind/calling-gdscript.html#function-calls),
+godot-rust also provides a type-safe way to defer execution until the next frame
+with `run_deferred`.
+
+```rust
+use godot::prelud::*;
+
+#[derive(GodotClass)]
+#[class(init, base=Node)]
+struct Game {
+    base: Base<Node>,
+}
+
+#[godot_api]
+impl Game {
+    fn now_and_later(&mut self) {
+        godot_print!("This runs at the beginning of the frame!");
+
+        self.run_deferred(|_this| {
+            godot_print!("This runs at the end of the frame!");
+        });
+    }
+}
+````
+
+
+## Futures
+
+Rust futures are fully supported for asynchronous programming.
+The key requirement is that a Godot pointer is passed to
+`godot::task::spawn`. For this reason,
+connected callbacks should accept a Godot pointer
+instead of the base class directly.
+
+```rust
+use godot::prelude::*;
+
+#[derive(GodotClass)]
+#[class(init, base=Node)]
+struct Game {
+    base: Base<Node>,
+}
+
+#[godot_api]
+impl Game {
+    async fn sleep(&self, duration: f64) {
+        // Your logic to sleep here
+    }
+
+    /// Show one message immediately and another after one second.
+    #[func(gd_self)]
+    fn show_messages(this: Gd<Self>, _area: Gd<Node2D>) {
+        godot::task::spawn(async move {
+            godot_print!("Immediate message!");
+
+            this.bind().sleep(1.0).await;
+
+            godot_print!("Message after one second!");
+        });
+    }
+}
+```
+
+While it is possible to obtain
+[a Godot pointer](https://godot-rust.github.io/book/register/functions.html?highlight=bind_mut#calling-rust-methods-binds),
+inside a class method `bind()` and `bind_mut()` cannot return a guarded object
+if the instance is already implicitly bound for the current method call.
+
+The following example demonstrates how this can fail.
+
+```rust
+#[godot_api]
+impl Game {
+    fn crash_the_program(&mut self) {
+        let gd = self.to_gd();
+
+        // `drop` is a no-op on a borrowed value.
+        std::mem::drop(self);
+
+        godot::task::spawn(async move {
+            // `self` already has an implicit `bind_mut()` from the method call.
+            // Attempting to bind again will crash the program.
+            gd.bind_mut();
+        });
+    }
+}
+```
+
+Additionally, because Rust and Godot run in the same process (and often on the
+same thread), blocking the thread while waiting for a future will freeze the
+program.
+
+```rust
+#[godot_api]
+impl Game {
+    async fn sleep(&self, duration: f64) {
+        // Your logic to sleep here
+    }
+
+    fn freeze_the_program(&mut self) {
+        // The program freezes when `block_on()` is called here.
+        //
+        // Instead, use `godot::task::spawn()` to start async tasks.
+        futures::executor::block_on(self.sleep(1.0));
+    }
+}
+```


### PR DESCRIPTION
# The problem this PR is trying to solve:

1. More complete documentation.  
2. For people going through the [godot game tutorials ](https://docs.godotengine.org/en/stable/getting_started/first_2d_game/index.html), searching for keywords will return meaninful results.

Example:

<img width="1188" height="677" alt="スクリーンショット 2026-05-07 11 56 52" src="https://github.com/user-attachments/assets/fadf7d93-639f-4668-ad53-ae851577beaa" />

<img width="1243" height="807" alt="スクリーンショット 2026-05-07 11 58 29" src="https://github.com/user-attachments/assets/d4676910-dda0-4fac-af1c-914e510f3298" />

# The proposed solution
 
This PR proposes a new `Futures and Deferred Functions` section to help explain async in rust-godot.  There was a lot of work to related functionality for typesafe deferred function calls and futures... we should show it off in the documentation!

<img width="1381" height="834" alt="スクリーンショット 2026-05-07 11 59 40" src="https://github.com/user-attachments/assets/ddff5a69-80b0-42be-8d3d-4f2b4f3a1916" />
<br><br>

Feedback welcome!  This is just a draft for now!  Thank you for your time!