### PR TITLE
Update Android NDK version in export-android.md

### DIFF
--- a/src/toolchain/export-android.md
+++ b/src/toolchain/export-android.md
@@ -79,7 +79,7 @@ Android target, as of the writing of this.
 Assuming the following things:
 
 1. Android CLI is installed in the `$HOME` folder.
-2. Godot is still relying on Android NDK version 23.2.8568313. Check
+2. Godot is relying on Android NDK version 29.0.14206865. Check
 [here](https://github.com/godotengine/godot/blob/master/platform/android/java/app/config.gradle).
 3. The downloaded Android CLI version is: 11076708_latest (update this to be the version you downloaded).
 4. This is being run on Linux. Change the `linux-x86_64` folder in `CLANG_PATH` and `CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER`

--- a/src/toolchain/export-android.md
+++ b/src/toolchain/export-android.md
@@ -79,8 +79,7 @@ Android target, as of the writing of this.
 Assuming the following things:
 
 1. Android CLI is installed in the `$HOME` folder.
-2. Godot is relying on Android NDK version 29.0.14206865. Check
-[here](https://github.com/godotengine/godot/blob/master/platform/android/java/app/config.gradle).
+2. The NDK version is [here](https://github.com/godotengine/godot/blob/master/platform/android/java/app/config.gradle).
 3. The downloaded Android CLI version is: 11076708_latest (update this to be the version you downloaded).
 4. This is being run on Linux. Change the `linux-x86_64` folder in `CLANG_PATH` and `CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER`
 to be your host machine's operating system.


### PR DESCRIPTION
### Description
This PR updates an outdated reference to the Android NDK version in the Android export documentation (`toolchain/export-android.md`). 

The document previously stated that Godot relies on NDK version `23.2.8568313`, which is outdated. It has been updated to reference the correct current version, `29.0.14206865`.

### Changes
* Updated NDK version string from `23.2.8568313` to `29.0.14206865` in the Android export example.

### Checklist
- [x] The change is a simple documentation typo/version fix.
- [x] No code modifications were made.