### PR TITLE
Show full program context when eye button is clicked in Hello World example

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -26,11 +26,8 @@ additional-css = ["config/mdbook-admonish.css", "config/tomorrow-noon.css"]
 default-theme = "godot-rust-light"
 preferred-dark-theme = "godot-rust-dark"
 
-# Snippets in this book are library code (cdylib entry points, #[godot_api] impls, ...) and
-# depend on the `godot` crate, so none of them can run on play.rust-lang.org. Without this,
-# mdbook silently wraps every Rust block in a hidden `fn main() { ... }`, which the "show
-# hidden lines" eye icon then reveals as if it were real code. Explicit `# ` hidden lines
-# still work as usual.
+# Disable play.rust-lang.org and the play button on code examples
+# by extension.
 [output.html.playground]
 runnable = false
 

--- a/book.toml
+++ b/book.toml
@@ -26,6 +26,14 @@ additional-css = ["config/mdbook-admonish.css", "config/tomorrow-noon.css"]
 default-theme = "godot-rust-light"
 preferred-dark-theme = "godot-rust-dark"
 
+# Snippets in this book are library code (cdylib entry points, #[godot_api] impls, ...) and
+# depend on the `godot` crate, so none of them can run on play.rust-lang.org. Without this,
+# mdbook silently wraps every Rust block in a hidden `fn main() { ... }`, which the "show
+# hidden lines" eye icon then reveals as if it were real code. Explicit `# ` hidden lines
+# still work as usual.
+[output.html.playground]
+runnable = false
+
 
 [output.html.redirect]
 

--- a/src/intro/code/hello-world-phpr-update.rs
+++ b/src/intro/code/hello-world-phpr-update.rs
@@ -3,8 +3,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Note: This code contains the updated version of the physics_process function.
-
 // ANCHOR: entry-point
 // ANCHOR: class-declaration
 use godot::prelude::*;
@@ -22,10 +20,10 @@ use godot::classes::Sprite2D;
 #[derive(GodotClass)]
 #[class(base=Sprite2D)]
 struct Player {
-    speed: f64,
-    angular_speed: f64,
+    speed: f32,
+    angular_speed: f32,
 
-    base: Base<Sprite2D>
+    base: Base<Sprite2D>,
 }
 // ANCHOR_END: class-declaration
 
@@ -36,21 +34,23 @@ use godot::classes::ISprite2D;
 
 #[godot_api]
 impl ISprite2D for Player {
-// ANCHOR_END: init
-// ANCHOR_END: physics-process
-// ANCHOR_END: rotate
+    // ANCHOR_END: init
+    // ANCHOR_END: physics-process
+    // ANCHOR_END: rotate
     // ANCHOR: init
     fn init(base: Base<Sprite2D>) -> Self {
         godot_print!("Hello, world!"); // Prints to the Godot console
 
         Self {
             speed: 400.0,
-            angular_speed: std::f64::consts::PI,
+            angular_speed: std::f32::consts::PI,
             base,
         }
     }
     // ANCHOR_END: init
 
+    // This snippet contains the updated physics_process block.
+    // delta may also be f64.
     // ANCHOR: physics-process
     fn physics_process(&mut self, delta: f32) {
         // GDScript code:
@@ -59,7 +59,7 @@ impl ISprite2D for Player {
         // var velocity = Vector2.UP.rotated(rotation) * speed
         // position += velocity * delta
 
-        let radians = self.angular_speed as f32 * delta;
+        let radians = self.angular_speed * delta;
         self.base_mut().rotate(radians);
 
         let rotation = self.base().get_rotation();
@@ -73,16 +73,17 @@ impl ISprite2D for Player {
         // );
     }
     // ANCHOR_END: physics-process
-// ANCHOR: init
+    // ANCHOR: init
 }
 // ANCHOR_END: init
 // ANCHOR_END: rotate
 
+// amount is allowed to be f64 too
 // ANCHOR: custom-api
 #[godot_api]
 impl Player {
     #[func]
-    fn increase_speed(&mut self, amount: f64) {
+    fn increase_speed(&mut self, amount: f32) {
         self.speed += amount;
         self.signals().speed_increased().emit();
     }

--- a/src/intro/code/hello-world-phpr-update.rs
+++ b/src/intro/code/hello-world-phpr-update.rs
@@ -52,14 +52,14 @@ impl ISprite2D for Player {
     // ANCHOR_END: init
 
     // ANCHOR: physics-process
-    fn physics_process(&mut self, delta: f64) {
+    fn physics_process(&mut self, delta: f32) {
         // GDScript code:
         //
         // rotation += angular_speed * delta
         // var velocity = Vector2.UP.rotated(rotation) * speed
         // position += velocity * delta
 
-        let radians = (self.angular_speed * delta) as f32;
+        let radians = self.angular_speed as f32 * delta;
         self.base_mut().rotate(radians);
 
         let rotation = self.base().get_rotation();

--- a/src/intro/code/hello-world-phpr-update.rs
+++ b/src/intro/code/hello-world-phpr-update.rs
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+// Note: This code contains the updated version of the physics_process function.
+
 // ANCHOR: entry-point
 // ANCHOR: class-declaration
 use godot::prelude::*;
@@ -51,13 +53,24 @@ impl ISprite2D for Player {
 
     // ANCHOR: physics-process
     fn physics_process(&mut self, delta: f64) {
-        // In GDScript, this would be:
+        // GDScript code:
+        //
         // rotation += angular_speed * delta
+        // var velocity = Vector2.UP.rotated(rotation) * speed
+        // position += velocity * delta
 
         let radians = (self.angular_speed * delta) as f32;
         self.base_mut().rotate(radians);
-        // The 'rotate' method requires a f32,
-        // therefore we convert 'self.angular_speed * delta' which is a f64 to a f32
+
+        let rotation = self.base().get_rotation();
+        let velocity = Vector2::UP.rotated(rotation) * self.speed as f32;
+        self.base_mut().translate(velocity * delta as f32);
+
+        // or verbose:
+        // let this = self.base_mut();
+        // this.set_position(
+        //     this.position() + velocity * delta as f32
+        // );
     }
     // ANCHOR_END: physics-process
 // ANCHOR: init

--- a/src/intro/code/hello-world.rs
+++ b/src/intro/code/hello-world.rs
@@ -1,0 +1,110 @@
+// Copyright (c) godot-rust; Bromeon and contributors.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Complete source for the Hello World tutorial. Every code block in
+// src/intro/hello-world.md includes one of the anchors below.
+//
+// Anchor names may be opened and closed more than once; mdbook concatenates the regions and
+// hides everything in between. That is how a block can show e.g. the `impl` header and one
+// method without the other methods.
+
+// ANCHOR: entry-point
+// ANCHOR: class-declaration
+use godot::prelude::*;
+// ANCHOR_END: class-declaration
+
+struct MyExtension;
+
+#[gdextension]
+unsafe impl ExtensionLibrary for MyExtension {}
+// ANCHOR_END: entry-point
+
+// ANCHOR: class-declaration
+use godot::classes::Sprite2D;
+
+#[derive(GodotClass)]
+#[class(base=Sprite2D)]
+struct Player {
+    speed: f64,
+    angular_speed: f64,
+
+    base: Base<Sprite2D>
+}
+// ANCHOR_END: class-declaration
+
+// ANCHOR: init
+// ANCHOR: physics-process
+// ANCHOR: rotate
+use godot::classes::ISprite2D;
+
+#[godot_api]
+impl ISprite2D for Player {
+// ANCHOR_END: init
+// ANCHOR_END: physics-process
+// ANCHOR_END: rotate
+    // ANCHOR: init
+    fn init(base: Base<Sprite2D>) -> Self {
+        godot_print!("Hello, world!"); // Prints to the Godot console
+
+        Self {
+            speed: 400.0,
+            angular_speed: std::f64::consts::PI,
+            base,
+        }
+    }
+    // ANCHOR_END: init
+
+    // ANCHOR: physics-process
+    // ANCHOR: rotate
+    fn physics_process(&mut self, delta: f64) {
+        // ANCHOR_END: physics-process
+        // In GDScript, this would be:
+        // rotation += angular_speed * delta
+
+        // ANCHOR: physics-process
+        // GDScript code:
+        //
+        // rotation += angular_speed * delta
+        // var velocity = Vector2.UP.rotated(rotation) * speed
+        // position += velocity * delta
+
+        let radians = (self.angular_speed * delta) as f32;
+        self.base_mut().rotate(radians);
+        // The 'rotate' method requires a f32,
+        // therefore we convert 'self.angular_speed * delta' which is a f64 to a f32
+        // ANCHOR_END: rotate
+
+        let rotation = self.base().get_rotation();
+        let velocity = Vector2::UP.rotated(rotation) * self.speed as f32;
+        self.base_mut().translate(velocity * delta as f32);
+
+        // or verbose:
+        // let this = self.base_mut();
+        // this.set_position(
+        //     this.position() + velocity * delta as f32
+        // );
+    // ANCHOR: rotate
+    }
+    // ANCHOR_END: physics-process
+// ANCHOR: init
+// ANCHOR: physics-process
+}
+// ANCHOR_END: init
+// ANCHOR_END: physics-process
+// ANCHOR_END: rotate
+
+// ANCHOR: custom-api
+#[godot_api]
+impl Player {
+    #[func]
+    fn increase_speed(&mut self, amount: f64) {
+        self.speed += amount;
+        self.signals().speed_increased().emit();
+    }
+
+    #[signal]
+    fn speed_increased();
+}
+// ANCHOR_END: custom-api

--- a/src/intro/code/hello-world.rs
+++ b/src/intro/code/hello-world.rs
@@ -20,10 +20,10 @@ use godot::classes::Sprite2D;
 #[derive(GodotClass)]
 #[class(base=Sprite2D)]
 struct Player {
-    speed: f64,
-    angular_speed: f64,
+    speed: f32,
+    angular_speed: f32,
 
-    base: Base<Sprite2D>
+    base: Base<Sprite2D>,
 }
 // ANCHOR_END: class-declaration
 
@@ -34,42 +34,44 @@ use godot::classes::ISprite2D;
 
 #[godot_api]
 impl ISprite2D for Player {
-// ANCHOR_END: init
-// ANCHOR_END: physics-process
-// ANCHOR_END: rotate
+    // ANCHOR_END: init
+    // ANCHOR_END: physics-process
+    // ANCHOR_END: rotate
     // ANCHOR: init
     fn init(base: Base<Sprite2D>) -> Self {
         godot_print!("Hello, world!"); // Prints to the Godot console
 
         Self {
             speed: 400.0,
-            angular_speed: std::f64::consts::PI,
+            angular_speed: std::f32::consts::PI,
             base,
         }
     }
     // ANCHOR_END: init
 
+    // delta may also be f64.
     // ANCHOR: physics-process
     fn physics_process(&mut self, delta: f32) {
         // In GDScript, this would be:
         // rotation += angular_speed * delta
 
-        let radians = self.angular_speed as f32 * delta;
+        let radians = self.angular_speed * delta;
         self.base_mut().rotate(radians);
         // The 'rotate' method requires a f32,
         // therefore we convert 'self.angular_speed * delta' which is a f64 to a f32
     }
     // ANCHOR_END: physics-process
-// ANCHOR: init
+    // ANCHOR: init
 }
 // ANCHOR_END: init
 // ANCHOR_END: rotate
 
+// amount is allowed to be f64 too
 // ANCHOR: custom-api
 #[godot_api]
 impl Player {
     #[func]
-    fn increase_speed(&mut self, amount: f64) {
+    fn increase_speed(&mut self, amount: f32) {
         self.speed += amount;
         self.signals().speed_increased().emit();
     }

--- a/src/intro/code/hello-world.rs
+++ b/src/intro/code/hello-world.rs
@@ -50,11 +50,11 @@ impl ISprite2D for Player {
     // ANCHOR_END: init
 
     // ANCHOR: physics-process
-    fn physics_process(&mut self, delta: f64) {
+    fn physics_process(&mut self, delta: f32) {
         // In GDScript, this would be:
         // rotation += angular_speed * delta
 
-        let radians = (self.angular_speed * delta) as f32;
+        let radians = self.angular_speed as f32 * delta;
         self.base_mut().rotate(radians);
         // The 'rotate' method requires a f32,
         // therefore we convert 'self.angular_speed * delta' which is a f64 to a f32

--- a/src/intro/hello-world.md
+++ b/src/intro/hello-world.md
@@ -332,7 +332,7 @@ Now that initialization is sorted out, we can move on to actual logic. We would 
 the `process()` method. This corresponds to GDScript's `_process()`. If you need a fixed framerate, use `physics_process()` instead.
 
 ```rust
-{{#rustdoc_include code/hello-world.rs:rotate}}
+{{#rustdoc_include code/hello-world.rs:physics-process}}
 ```
 
 GDScript uses property syntax here; Rust requires explicit method calls instead. Also, access to base class methods -- such as `rotate()`
@@ -365,7 +365,7 @@ Check out the [command-line tutorial][godot-command-line] for more information.
 We now add a translation component to the sprite, following [the upstream tutorial][tutorial-full-script].
 
 ```rust
-{{#rustdoc_include code/hello-world.rs:physics-process}}
+{{#rustdoc_include code/hello-world-phpr-update.rs:physics-process}}
 ```
 
 The result should be a sprite that rotates with an offset.
@@ -381,7 +381,7 @@ annotated with `#[godot_api]`. However, this time we are using an _inherent_ `im
 Concretely, we add a function to increase the speed, and a signal to notify other objects of the speed change.
 
 ```rust
-{{#rustdoc_include code/hello-world.rs:custom-api}}
+{{#rustdoc_include code/hello-world-phpr-update.rs:custom-api}}
 ```
 
 `#[godot_api]` takes again the role of exposing the API to the Godot engine. But there are also two new attributes:

--- a/src/intro/hello-world.md
+++ b/src/intro/hello-world.md
@@ -201,13 +201,13 @@ the GDExtension. Setting this up requires quite some low-level [FFI][wikipedia-f
 
 In your `lib.rs`, replace the template with the following:
 
+```admonish tip
+When hovering over a rust code block, click the eye icon in the top right to see how the snippet fits
+within the entire file.
+```
+
 ```rust
-use godot::prelude::*;
-
-struct MyExtension;
-
-#[gdextension]
-unsafe impl ExtensionLibrary for MyExtension {}
+{{#rustdoc_include code/hello-world.rs:entry-point}}
 ```
 
 There are multiple things going on here:
@@ -271,17 +271,7 @@ This can be either defined in `lib.rs` or in a separate file `player.rs`.
 In case you go for the latter, don't forget to declare `mod player;` in your `lib.rs` file.
 
 ```rust
-use godot::prelude::*;
-use godot::classes::Sprite2D;
-
-#[derive(GodotClass)]
-#[class(base=Sprite2D)]
-struct Player {
-    speed: f64,
-    angular_speed: f64,
-
-    base: Base<Sprite2D>
-}
+{{#rustdoc_include code/hello-world.rs:class-declaration}}
 ```
 
 Let's break this down.
@@ -322,20 +312,7 @@ Now let's add some logic. We start with overriding the `init` method, also known
 This corresponds to GDScript's `_init()` function.
 
 ```rust
-use godot::classes::ISprite2D;
-
-#[godot_api]
-impl ISprite2D for Player {
-    fn init(base: Base<Sprite2D>) -> Self {
-        godot_print!("Hello, world!"); // Prints to the Godot console
-        
-        Self {
-            speed: 400.0,
-            angular_speed: std::f64::consts::PI,
-            base,
-        }
-    }
-}
+{{#rustdoc_include code/hello-world.rs:init}}
 ```
 
 Again, those are multiple pieces working together, let's go through them one by one.
@@ -355,22 +332,7 @@ Now that initialization is sorted out, we can move on to actual logic. We would 
 the `process()` method. This corresponds to GDScript's `_process()`. If you need a fixed framerate, use `physics_process()` instead.
 
 ```rust
-use godot::classes::ISprite2D;
-
-#[godot_api]
-impl ISprite2D for Player {
-    fn init(base: Base<Sprite2D>) -> Self { /* as before */ }
-
-    fn physics_process(&mut self, delta: f64) {
-        // In GDScript, this would be: 
-        // rotation += angular_speed * delta
-        
-        let radians = (self.angular_speed * delta) as f32;
-        self.base_mut().rotate(radians);
-        // The 'rotate' method requires a f32, 
-        // therefore we convert 'self.angular_speed * delta' which is a f64 to a f32
-    }
-}
+{{#rustdoc_include code/hello-world.rs:rotate}}
 ```
 
 GDScript uses property syntax here; Rust requires explicit method calls instead. Also, access to base class methods -- such as `rotate()`
@@ -403,33 +365,7 @@ Check out the [command-line tutorial][godot-command-line] for more information.
 We now add a translation component to the sprite, following [the upstream tutorial][tutorial-full-script].
 
 ```rust
-use godot::classes::ISprite2D;
-
-#[godot_api]
-impl ISprite2D for Player {
-    fn init(base: Base<Sprite2D>) -> Self { /* as before */ }
-
-    fn physics_process(&mut self, delta: f64) {
-        // GDScript code:
-        //
-        // rotation += angular_speed * delta
-        // var velocity = Vector2.UP.rotated(rotation) * speed
-        // position += velocity * delta
-        
-        let radians = (self.angular_speed * delta) as f32;
-        self.base_mut().rotate(radians);
-
-        let rotation = self.base().get_rotation();
-        let velocity = Vector2::UP.rotated(rotation) * self.speed as f32;
-        self.base_mut().translate(velocity * delta as f32);
-        
-        // or verbose: 
-        // let this = self.base_mut();
-        // this.set_position(
-        //     this.position() + velocity * delta as f32
-        // );
-    }
-}
+{{#rustdoc_include code/hello-world.rs:physics-process}}
 ```
 
 The result should be a sprite that rotates with an offset.
@@ -445,17 +381,7 @@ annotated with `#[godot_api]`. However, this time we are using an _inherent_ `im
 Concretely, we add a function to increase the speed, and a signal to notify other objects of the speed change.
 
 ```rust
-#[godot_api]
-impl Player {
-    #[func]
-    fn increase_speed(&mut self, amount: f64) {
-        self.speed += amount;
-        self.signals().speed_increased().emit();
-    }
-
-    #[signal]
-    fn speed_increased();
-}
+{{#rustdoc_include code/hello-world.rs:custom-api}}
 ```
 
 `#[godot_api]` takes again the role of exposing the API to the Godot engine. But there are also two new attributes:


### PR DESCRIPTION
# Why

When I read through a rust book, I like to click on the little eye icon to see how a block of code fits into the entirety of the program. I found myself confused after reading through the Hello World example. 

# Problem

The current behavior of the eye button wraps the block of code in a main function call. This is not verbose enough and confusing in my opinion. Also, none of the playground examples compile.

# Proposed Changes

- Remove playground functionality
- When the eye icon is pressed, show the rust block in relation to the entire `lib.rs` file

### More details about the changes

The play button is removed by adding the block below to `book.toml`
```toml
[output.html.playground]
runnable = false
```

As for showing code when the eye icon is pressed, I created a file at `src/intro/code/hello-world.rs` that has anchors placed in it, controlling what code is shown. I removed the line `fn init(base: Base<Sprite2D>) -> Self { /* as before */ }` from being mentioned as the user could simply click the eye and see the implementation. Finally, I added an admonish tip to click the eye before the `Rust entry point` block.

# AI Usage

I used Claude Opus 5 in this PR. Claude stitched together the code blocks and placed most of the anchor points in `src/intro/code/hello-world.rs`. I modified the anchor points to remain loyal to the original rust blocks.

# Testing

Using Godot 4.7.1, I saw `icon.svg` moving in a circle from the code in `src/intro/code/hello-world.rs` when running the scene. I have not tested whether the `Custom Rust APIs` block functions.

# Final Notes

If anything could be changed, let me know.